### PR TITLE
Remove upstream llvm repo, drop llvm 10, introduce arm builds

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,6 +14,9 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
+      rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
+      arch-skipping-maximize-build-space: '["arm64"]'
+      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
     uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main

--- a/cilium-operator-generic/rockcraft.yaml
+++ b/cilium-operator-generic/rockcraft.yaml
@@ -8,6 +8,7 @@ base: bare
 build-base: ubuntu@22.04
 platforms:
   amd64:
+  arm64:
 
 environment:
   GOPS_CONFIG_DIR: "/"

--- a/cilium/iptables-wrapper-installer.sh
+++ b/cilium/iptables-wrapper-installer.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+# https://github.com/kubernetes-sigs/iptables-wrappers/blob/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eux
+
+# Find iptables binary location
+if [ -n "$OVERRIDE_SBIN" ]; then
+    sbin="$OVERRIDE_SBIN"
+elif [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+if [ -n "$OVERRIDE_PATH" ]; then
+    target="$OVERRIDE_PATH"
+else
+    target="$sbin"
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -n "$OVERRIDE_ALTSTYLE" ]; then
+    altstyle="$OVERRIDE_ALTSTYLE"
+elif [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[0123]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.4 or newer." 1>&2
+        exit 1
+        ;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${target}/iptables-wrapper"
+cat > "${target}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${target}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${target}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${target}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${target}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/cilium/rockcraft.yaml
+++ b/cilium/rockcraft.yaml
@@ -8,6 +8,7 @@ base: ubuntu@22.04
 build-base: ubuntu@22.04
 platforms:
   amd64:
+  arm64:
 
 environment:
   HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
@@ -18,18 +19,6 @@ services:
     command: /usr/bin/cilium-dbg
     override: replace
     startup: enabled
-
-package-repositories:
-  - type: apt
-    url: http://apt.llvm.org/jammy/
-    suites: ["llvm-toolchain-jammy-15"]
-    components: ["main"]
-    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
-  - type: apt
-    url: http://apt.llvm.org/focal/
-    suites: ["llvm-toolchain-focal-10"]
-    components: ["main"]
-    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
 
 parts:
   bazelisk:
@@ -307,16 +296,20 @@ parts:
     source-type: git
     source: https://github.com/cilium/cilium.git
     source-tag: v1.15.2
-    source-depth: 1
     build-packages:
-      - clang-10
-      - llvm-10
+      - clang-15
+      - llvm-15
     stage-packages:
-      - clang-10
-      - llvm-10
+      - clang-15
+      - llvm-15
     build-environment:
      - DISABLE_ENVOY_INSTALLATION: 1
+     - PKG_BUILD: 1
+     - NOSTRIP: 0
+     - NOOPT: 0
     override-build: |
+      # Cherry picking new debug symbols introduced in newer LLVM versions to ignore list
+      git cherry-pick b91046955d6ba6e335d8b71037e0a5154a09d064 --strategy-option theirs
       make build-container
       export DESTDIR=$CRAFT_PART_INSTALL
       make install-container-binary
@@ -330,9 +323,9 @@ parts:
       cp $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh $CRAFT_PART_INSTALL/
       cp $CRAFT_PART_SRC/plugins/cilium-cni/cni-uninstall.sh $CRAFT_PART_INSTALL/
 
-      cp -a $CRAFT_PART_INSTALL/usr/bin/clang-10 $CRAFT_PART_INSTALL/usr/bin/clang
-      cp -a $CRAFT_PART_INSTALL/usr/bin/llc-10 $CRAFT_PART_INSTALL/usr/bin/llc
-      cp -a $CRAFT_PART_INSTALL/usr/bin/llvm-objcopy-10 $CRAFT_PART_INSTALL/usr/bin/llvm-objcopy
+      cp -a $CRAFT_PART_INSTALL/usr/bin/clang-15 $CRAFT_PART_INSTALL/usr/bin/clang
+      cp -a $CRAFT_PART_INSTALL/usr/bin/llc-15 $CRAFT_PART_INSTALL/usr/bin/llc
+      cp -a $CRAFT_PART_INSTALL/usr/bin/llvm-objcopy-15 $CRAFT_PART_INSTALL/usr/bin/llvm-objcopy
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build

--- a/cilium/rockcraft.yaml
+++ b/cilium/rockcraft.yaml
@@ -164,65 +164,24 @@ parts:
       - kmod
       - ca-certificates
       - libz3-dev
-    stage:
-      - -usr/lib/x86_64-linux-gnu/libmnl.so.0.2.0
-      - -usr/lib/x86_64-linux-gnu/libmnl.so.0
-      - -usr/lib/aarch64-linux-gnu/libmnl.so.0.2.0
-      - -usr/lib/aarch64-linux-gnu/libmnl.so.0
-
-  libmnl:
-    after : [build-deps]
-    plugin: autotools
-    source: https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
-    prime:
-      - -usr/local/include
-
-  libnftnl:
-    after: [libmnl]
-    plugin: autotools
-    source: https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.2.1.tar.bz2
-    build-environment:
-      - LIBMNL_LIBS: "-L$CRAFT_STAGE/usr/local/lib"
-      - LIBMNL_CFLAGS: "-I$CRAFT_STAGE/usr/local/include"
-    prime:
-      - -usr/local/include
 
   iptables:
-    after: [libnftnl]
-    source: https://www.netfilter.org/projects/iptables/files/iptables-1.8.8.tar.bz2
-    plugin: autotools
-    build-environment:
-      - LIBMNL_LIBS: "-L$CRAFT_STAGE/usr/local/lib"
-      - LIBMNL_CFLAGS: "-I$CRAFT_STAGE/usr/local/include"
-      - LIBNFTNL_LIBS: "-L$CRAFT_STAGE/usr/local/lib"
-      - LIBNFTNL_CFLAGS: "-I$CRAFT_STAGE/usr/local/include"
-    autotools-configure-parameters:
-      - "--prefix=/usr"
-      - "--exec-prefix=/"
-      - "--disable-shared"
-      - "--enable-static"
-    stage:
-      - -usr/share
-      - -lib/pkgconfig
-      - -bin/iptables-xml
-    organize:
-      sbin: usr/sbin
+    plugin: nil
+    stage-packages:
+      - iptables
 
   iptables-wrapper:
     after: [iptables]
     plugin: nil
-    source-type: git
-    source: https://github.com/kubernetes-sigs/iptables-wrappers.git
-    source-commit: "e139a115350974aac8a82ec4b815d2845f86997e"
-    source-depth: 1
-    override-build: |
-      mv /usr/sbin /usr/sbin-tmp
-      ln -sf $CRAFT_STAGE/usr/sbin /usr/sbin
-      ./iptables-wrapper-installer.sh
-      mkdir -p $CRAFT_PART_INSTALL/usr/sbin
-      cp $CRAFT_STAGE/usr/sbin/iptables-wrapper $CRAFT_PART_INSTALL/usr/sbin/
-      rm -rf /usr/sbin
-      mv /usr/sbin-tmp /usr/sbin
+    source-type: file
+    source: ./iptables-wrapper-installer.sh
+    build-environment:
+    - OVERRIDE_PATH: "$CRAFT_PRIME/usr/sbin"
+    - OVERRIDE_SBIN: "/usr/sbin"
+    - OVERRIDE_ALTSTYLE: "none"
+    override-prime: |
+      craftctl default
+      $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
 
   bpftool:
     plugin: make

--- a/cilium/rockcraft.yaml
+++ b/cilium/rockcraft.yaml
@@ -167,14 +167,13 @@ parts:
     stage:
       - -usr/lib/x86_64-linux-gnu/libmnl.so.0.2.0
       - -usr/lib/x86_64-linux-gnu/libmnl.so.0
+      - -usr/lib/aarch64-linux-gnu/libmnl.so.0.2.0
+      - -usr/lib/aarch64-linux-gnu/libmnl.so.0
 
   libmnl:
     after : [build-deps]
     plugin: autotools
     source: https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
-    autotools-configure-parameters:
-      - "--prefix=/lib"
-      - "--libdir=/lib/x86_64-linux-gnu"
     prime:
       - -usr/local/include
 
@@ -182,11 +181,9 @@ parts:
     after: [libmnl]
     plugin: autotools
     source: https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.2.1.tar.bz2
-    autotools-configure-parameters:
-      - "--prefix=/lib"
-      - "--libdir=/lib/x86_64-linux-gnu"
     build-environment:
-      - LIBMNL_LIBS: $CRAFT_STAGE/lib/x86_64-linux-gnu
+      - LIBMNL_LIBS: "-L$CRAFT_STAGE/usr/local/lib"
+      - LIBMNL_CFLAGS: "-I$CRAFT_STAGE/usr/local/include"
     prime:
       - -usr/local/include
 
@@ -195,8 +192,10 @@ parts:
     source: https://www.netfilter.org/projects/iptables/files/iptables-1.8.8.tar.bz2
     plugin: autotools
     build-environment:
-      - LIBMNL_LIBS: $CRAFT_STAGE/lib/x86_64-linux-gnu
-      - LIBNFTNL_LIBS: $CRAFT_STAGE/lib/x86_64-linux-gnu
+      - LIBMNL_LIBS: "-L$CRAFT_STAGE/usr/local/lib"
+      - LIBMNL_CFLAGS: "-I$CRAFT_STAGE/usr/local/include"
+      - LIBNFTNL_LIBS: "-L$CRAFT_STAGE/usr/local/lib"
+      - LIBNFTNL_CFLAGS: "-I$CRAFT_STAGE/usr/local/include"
     autotools-configure-parameters:
       - "--prefix=/usr"
       - "--exec-prefix=/"


### PR DESCRIPTION
* Removed upstream llvm repositories due to missing arm builds on llvm 10
* Dropped llvm 10 requirement(replaced by llvm 15 for everything)
* Switched to pulling iptables(1.8.7) from ubuntu repo instead
* Fixed iptables-wrapper not being staged properly
* Added a cherry picked commit that adds new debug symbols present in llvm 10+ to the ignore list(fixes the warnings)
* Introduced arm builds