### PR TITLE
Add cilium 1.16.5 rock

### DIFF
--- a/1.16.5/cilium-operator-generic/rockcraft.yaml
+++ b/1.16.5/cilium-operator-generic/rockcraft.yaml
@@ -1,7 +1,12 @@
+# NOTE(aznashwan): this was adapted from the existing ROCK definition
+# for release v1.16.3, the outlined changes being referenced from:
+#
+# * in cilium/cilium repo: git diff tags/1.16.3 tags/1.16.5 -- images/operator
+
 name: cilium-operator-generic
 summary: Cilium operator rock for the Cilium CNI.
 description: This rock is a drop in replacement for the cilium/operator-generic image.
-version: "1.16.3"
+version: "1.16.5"
 license: Apache-2.0
 
 base: bare
@@ -44,12 +49,14 @@ parts:
       - build-essential
       - pkg-config
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/Dockerfile#L66-L70
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/build-debug-wrapper.sh
   debug-wrapper:
     after: [build-deps, builder-img-deps]
     plugin: go
     source-type: git
     source: https://github.com/cilium/cilium.git
-    source-tag: v1.16.3
+    source-tag: v1.16.5
     source-subdir: images/builder
     build-environment:
       - CGO_ENABLED: 0
@@ -58,11 +65,14 @@ parts:
       go install github.com/go-delve/delve/cmd/dlv@latest
       go install -ldflags "-s -w" debug-wrapper.go
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/install-protoc.sh
   protoc:
     plugin: cmake
     source-type: git
     source: https://github.com/protocolbuffers/protobuf.git
-    source-tag: v28.2
+    # git diff tags/1.16.3 tags/1.16.5 -- .//images/builder/install-protoc.sh
+    # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/install-protoc.sh#L12
+    source-tag: v29.1
     source-submodules:
       - third_party/googletest
       - third_party/abseil-cpp
@@ -82,13 +92,15 @@ parts:
     - -usr/local/include/utf8_range.h
     - -usr/local/include/utf8_validity.h
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/install-protoplugins.sh
   protoplugins:
     plugin: go
     source: ""
     override-build: |
       go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@1adbea267b837660726952ed6711b348dee87aa5
-      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.1
-      go install github.com/mfridman/protoc-gen-go-json@v1.4.0
+      # git diff tags/1.16.3 tags/1.16.5 -- .//images/builder/install-protoplugins.sh
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.2
+      go install github.com/mfridman/protoc-gen-go-json@v1.4.1
       go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
   runtime-img-deps:
@@ -96,23 +108,27 @@ parts:
     stage-packages:
       - ca-certificates
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/Dockerfile#L20-L23
   gops:
     after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/google/gops.git
+    # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/build-gops.sh#L11-L12
     source-tag: v0.3.27
     build-environment:
       - CGO_ENABLED: 0
     override-build: |
       go install -ldflags "-s -w" ./...
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/operator/Dockerfile
+  # https://github.com/cilium/cilium/blob/v1.16.5/Makefile#L65-L66
   cilium-operator:
     after: [build-deps, builder-img-deps]
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
-    source-tag: v1.16.3
+    source-tag: v1.16.5
     override-build: |
       export VARIANT="generic"
       make build-container-operator-$VARIANT

--- a/1.16.5/cilium-operator-generic/rockcraft.yaml
+++ b/1.16.5/cilium-operator-generic/rockcraft.yaml
@@ -1,0 +1,123 @@
+name: cilium-operator-generic
+summary: Cilium operator rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/operator-generic image.
+version: "1.16.3"
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  GOPS_CONFIG_DIR: "/"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-operator-generic
+    override: replace
+    startup: enabled
+
+parts:
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      - go/1.22/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+
+  debug-wrapper:
+    after: [build-deps, builder-img-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.16.3
+    source-subdir: images/builder
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      cd $CRAFT_PART_SRC_WORK
+      go install github.com/go-delve/delve/cmd/dlv@latest
+      go install -ldflags "-s -w" debug-wrapper.go
+
+  protoc:
+    plugin: cmake
+    source-type: git
+    source: https://github.com/protocolbuffers/protobuf.git
+    source-tag: v28.2
+    source-submodules:
+      - third_party/googletest
+      - third_party/abseil-cpp
+      - third_party/jsoncpp
+    cmake-generator: Ninja
+    build-packages:
+      - g++
+      - git
+    override-build: |
+      cmake $CRAFT_PART_SRC -G Ninja \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_INSTALL_PREFIX="$CRAFT_PART_INSTALL/usr/local"
+      ninja install
+    stage:
+    - -usr/local/lib
+    - -usr/local/include/absl
+    - -usr/local/include/utf8_range.h
+    - -usr/local/include/utf8_validity.h
+
+  protoplugins:
+    plugin: go
+    source: ""
+    override-build: |
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@1adbea267b837660726952ed6711b348dee87aa5
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.1
+      go install github.com/mfridman/protoc-gen-go-json@v1.4.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - ca-certificates
+
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/google/gops.git
+    source-tag: v0.3.27
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      go install -ldflags "-s -w" ./...
+
+  cilium-operator:
+    after: [build-deps, builder-img-deps]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.16.3
+    override-build: |
+      export VARIANT="generic"
+      make build-container-operator-$VARIANT
+      export DESTDIR=$CRAFT_PART_INSTALL
+      make install-container-binary-operator-$VARIANT
+      make licenses-all
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/

--- a/1.16.5/cilium/envoy-fixes.patch
+++ b/1.16.5/cilium/envoy-fixes.patch
@@ -1,0 +1,271 @@
+From 285945d3fa51456d81f2d7af98fc38940c74a996 Mon Sep 17 00:00:00 2001
+From: root <root@rockcraft-cilium-on-amd64-for-amd64-9854116.lxd>
+Date: Thu, 16 Jan 2025 08:08:14 +0000
+Subject: [PATCH] move cel-cpp header definitions, fixing libstdc++-12
+
+---
+ WORKSPACE                                     |   3 +-
+ ...header-definitions-fixing-libstdc-12.patch | 121 ++++++++++++++++++
+ ...0006-cel-cpp-move-header-definitions.patch | 102 +++++++++++++++
+ 3 files changed, 225 insertions(+), 1 deletion(-)
+ create mode 100644 patches/0001-move-cel-cpp-header-definitions-fixing-libstdc-12.patch
+ create mode 100644 patches/0006-cel-cpp-move-header-definitions.patch
+
+diff --git a/WORKSPACE b/WORKSPACE
+index 2868aba..3dd0ddc 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -39,6 +39,7 @@ git_repository(
+         # https://github.com/envoyproxy/envoy/pull/31894
+         "@//patches:0004-Patch-cel-cpp-to-not-break-build.patch",
+         "@//patches:0005-original_dst_cluster-Avoid-multiple-hosts-for-the-sa.patch",
++        "@//patches:0006-cel-cpp-move-header-definitions.patch",
+     ],
+     # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
+     remote = "https://github.com/envoyproxy/envoy.git",
+@@ -68,7 +69,7 @@ envoy_dependencies()
+
+ load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+
+-envoy_dependencies_extra()
++envoy_dependencies_extra(ignore_root_user_error=True)
+
+ load("@envoy//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+
+diff --git a/patches/0001-move-cel-cpp-header-definitions-fixing-libstdc-12.patch b/patches/0001-move-cel-cpp-header-definitions-fixing-libstdc-12.patch
+new file mode 100644
+index 0000000..5c182c2
+--- /dev/null
++++ b/patches/0001-move-cel-cpp-header-definitions-fixing-libstdc-12.patch
+@@ -0,0 +1,121 @@
++From f8d60039e2ed0879697f0ac014907daab30dc2b5 Mon Sep 17 00:00:00 2001
++From: root <root@rockcraft-cilium-on-amd64-for-amd64-9854116.lxd>
++Date: Thu, 16 Jan 2025 08:08:14 +0000
++Subject: [PATCH] move cel-cpp header definitions, fixing libstdc++-12
++
++---
++ ...0006-cel-cpp-move-header-definitions.patch | 102 ++++++++++++++++++
++ 1 file changed, 102 insertions(+)
++ create mode 100644 patches/0006-cel-cpp-move-header-definitions.patch
++
++diff --git a/patches/0006-cel-cpp-move-header-definitions.patch b/patches/0006-cel-cpp-move-header-definitions.patch
++new file mode 100644
++index 0000000..924b97f
++--- /dev/null
+++++ b/patches/0006-cel-cpp-move-header-definitions.patch
++@@ -0,0 +1,102 @@
+++From 1d85e06a309d457010797aadc72bc7141c16b070 Mon Sep 17 00:00:00 2001
+++From: root <root@rockcraft-cilium-on-amd64-for-amd64-9854116.lxd>
+++Date: Thu, 16 Jan 2025 08:05:50 +0000
+++Subject: [PATCH] cel-cpp: move header definitions
+++
+++---
+++ bazel/cel-cpp-header-defs.patch | 70 +++++++++++++++++++++++++++++++++
+++ bazel/repositories.bzl          |  1 +
+++ 2 files changed, 71 insertions(+)
+++ create mode 100644 bazel/cel-cpp-header-defs.patch
+++
+++diff --git a/bazel/cel-cpp-header-defs.patch b/bazel/cel-cpp-header-defs.patch
+++new file mode 100644
+++index 0000000..bab38c2
+++--- /dev/null
++++++ b/bazel/cel-cpp-header-defs.patch
+++@@ -0,0 +1,70 @@
++++From 18cf5685e93fb8c07c807d913fabe9d1b54db87f Mon Sep 17 00:00:00 2001
++++From: CEL Dev Team <cel-dev@google.com>
++++Date: Thu, 7 Mar 2024 08:13:00 -0800
++++Subject: [PATCH] Move implementations from the header file.
++++
++++PiperOrigin-RevId: 613588519
++++---
++++ common/json.cc | 11 +++++++++++
++++ common/json.h  | 11 +++--------
++++ 2 files changed, 14 insertions(+), 8 deletions(-)
++++
++++diff --git a/common/json.cc b/common/json.cc
++++index 630a267ca..7946019bc 100644
++++--- a/common/json.cc
+++++++ b/common/json.cc
++++@@ -68,6 +68,17 @@ Json JsonBytes(const absl::Cord& value) {
++++   return JsonBytes(absl::string_view(static_cast<std::string>(value)));
++++ }
++++
+++++bool JsonArrayBuilder::empty() const { return impl_.get().empty(); }
+++++
+++++bool JsonArray::empty() const { return impl_.get().empty(); }
+++++
+++++JsonArray::JsonArray(internal::CopyOnWrite<Container> impl)
+++++    : impl_(std::move(impl)) {
+++++  if (impl_.get().empty()) {
+++++    impl_ = Empty();
+++++  }
+++++}
+++++
++++ namespace {
++++
++++ using internal::ProtoWireEncoder;
++++diff --git a/common/json.h b/common/json.h
++++index fe72492ce..77f0bd29d 100644
++++--- a/common/json.h
+++++++ b/common/json.h
++++@@ -124,7 +124,7 @@ class JsonArrayBuilder {
++++   JsonArrayBuilder& operator=(const JsonArrayBuilder&) = delete;
++++   JsonArrayBuilder& operator=(JsonArrayBuilder&&) = default;
++++
++++-  bool empty() const { return impl_.get().empty(); }
+++++  bool empty() const;
++++
++++   size_type size() const;
++++
++++@@ -187,7 +187,7 @@ class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonArray final {
++++   JsonArray& operator=(const JsonArray&) = default;
++++   JsonArray& operator=(JsonArray&&) = default;
++++
++++-  bool empty() const { return impl_.get().empty(); }
+++++  bool empty() const;
++++
++++   size_type size() const;
++++
++++@@ -223,12 +223,7 @@ class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonArray final {
++++
++++   static internal::CopyOnWrite<Container> Empty();
++++
++++-  explicit JsonArray(internal::CopyOnWrite<Container> impl)
++++-      : impl_(std::move(impl)) {
++++-    if (impl_.get().empty()) {
++++-      impl_ = Empty();
++++-    }
++++-  }
+++++  explicit JsonArray(internal::CopyOnWrite<Container> impl);
++++
++++   internal::CopyOnWrite<Container> impl_;
++++ };
++++
+++diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
+++index 3a82f6c..3d70304 100644
+++--- a/bazel/repositories.bzl
++++++ b/bazel/repositories.bzl
+++@@ -710,6 +710,7 @@ def _com_google_cel_cpp():
+++         patches = [
+++             "@envoy//bazel:cel-cpp.patch",
+++             "@envoy//bazel:cel-cpp-memory.patch",
++++            "@envoy//bazel:cel-cpp-header-defs.patch",
+++         ],
+++         patch_args = ["-p1"],
+++     )
+++--
+++2.43.0
+++
++--
++2.43.0
++
+diff --git a/patches/0006-cel-cpp-move-header-definitions.patch b/patches/0006-cel-cpp-move-header-definitions.patch
+new file mode 100644
+index 0000000..924b97f
+--- /dev/null
++++ b/patches/0006-cel-cpp-move-header-definitions.patch
+@@ -0,0 +1,102 @@
++From 1d85e06a309d457010797aadc72bc7141c16b070 Mon Sep 17 00:00:00 2001
++From: root <root@rockcraft-cilium-on-amd64-for-amd64-9854116.lxd>
++Date: Thu, 16 Jan 2025 08:05:50 +0000
++Subject: [PATCH] cel-cpp: move header definitions
++
++---
++ bazel/cel-cpp-header-defs.patch | 70 +++++++++++++++++++++++++++++++++
++ bazel/repositories.bzl          |  1 +
++ 2 files changed, 71 insertions(+)
++ create mode 100644 bazel/cel-cpp-header-defs.patch
++
++diff --git a/bazel/cel-cpp-header-defs.patch b/bazel/cel-cpp-header-defs.patch
++new file mode 100644
++index 0000000..bab38c2
++--- /dev/null
+++++ b/bazel/cel-cpp-header-defs.patch
++@@ -0,0 +1,70 @@
+++From 18cf5685e93fb8c07c807d913fabe9d1b54db87f Mon Sep 17 00:00:00 2001
+++From: CEL Dev Team <cel-dev@google.com>
+++Date: Thu, 7 Mar 2024 08:13:00 -0800
+++Subject: [PATCH] Move implementations from the header file.
+++
+++PiperOrigin-RevId: 613588519
+++---
+++ common/json.cc | 11 +++++++++++
+++ common/json.h  | 11 +++--------
+++ 2 files changed, 14 insertions(+), 8 deletions(-)
+++
+++diff --git a/common/json.cc b/common/json.cc
+++index 630a267ca..7946019bc 100644
+++--- a/common/json.cc
++++++ b/common/json.cc
+++@@ -68,6 +68,17 @@ Json JsonBytes(const absl::Cord& value) {
+++   return JsonBytes(absl::string_view(static_cast<std::string>(value)));
+++ }
+++
++++bool JsonArrayBuilder::empty() const { return impl_.get().empty(); }
++++
++++bool JsonArray::empty() const { return impl_.get().empty(); }
++++
++++JsonArray::JsonArray(internal::CopyOnWrite<Container> impl)
++++    : impl_(std::move(impl)) {
++++  if (impl_.get().empty()) {
++++    impl_ = Empty();
++++  }
++++}
++++
+++ namespace {
+++
+++ using internal::ProtoWireEncoder;
+++diff --git a/common/json.h b/common/json.h
+++index fe72492ce..77f0bd29d 100644
+++--- a/common/json.h
++++++ b/common/json.h
+++@@ -124,7 +124,7 @@ class JsonArrayBuilder {
+++   JsonArrayBuilder& operator=(const JsonArrayBuilder&) = delete;
+++   JsonArrayBuilder& operator=(JsonArrayBuilder&&) = default;
+++
+++-  bool empty() const { return impl_.get().empty(); }
++++  bool empty() const;
+++
+++   size_type size() const;
+++
+++@@ -187,7 +187,7 @@ class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonArray final {
+++   JsonArray& operator=(const JsonArray&) = default;
+++   JsonArray& operator=(JsonArray&&) = default;
+++
+++-  bool empty() const { return impl_.get().empty(); }
++++  bool empty() const;
+++
+++   size_type size() const;
+++
+++@@ -223,12 +223,7 @@ class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonArray final {
+++
+++   static internal::CopyOnWrite<Container> Empty();
+++
+++-  explicit JsonArray(internal::CopyOnWrite<Container> impl)
+++-      : impl_(std::move(impl)) {
+++-    if (impl_.get().empty()) {
+++-      impl_ = Empty();
+++-    }
+++-  }
++++  explicit JsonArray(internal::CopyOnWrite<Container> impl);
+++
+++   internal::CopyOnWrite<Container> impl_;
+++ };
+++
++diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
++index 3a82f6c..3d70304 100644
++--- a/bazel/repositories.bzl
+++++ b/bazel/repositories.bzl
++@@ -710,6 +710,7 @@ def _com_google_cel_cpp():
++         patches = [
++             "@envoy//bazel:cel-cpp.patch",
++             "@envoy//bazel:cel-cpp-memory.patch",
+++            "@envoy//bazel:cel-cpp-header-defs.patch",
++         ],
++         patch_args = ["-p1"],
++     )
++--
++2.43.0
++
+--
+2.43.0

--- a/1.16.5/cilium/iptables-wrapper-installer.sh
+++ b/1.16.5/cilium/iptables-wrapper-installer.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+# https://github.com/kubernetes-sigs/iptables-wrappers/blob/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eux
+
+# Find iptables binary location
+if [ -n "$OVERRIDE_SBIN" ]; then
+    sbin="$OVERRIDE_SBIN"
+elif [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+if [ -n "$OVERRIDE_PATH" ]; then
+    target="$OVERRIDE_PATH"
+else
+    target="$sbin"
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -n "$OVERRIDE_ALTSTYLE" ]; then
+    altstyle="$OVERRIDE_ALTSTYLE"
+elif [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[0123]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.4 or newer." 1>&2
+        exit 1
+        ;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${target}/iptables-wrapper"
+cat > "${target}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${target}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${target}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${target}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${target}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/1.16.5/cilium/rockcraft.yaml
+++ b/1.16.5/cilium/rockcraft.yaml
@@ -1,0 +1,299 @@
+name: cilium
+summary: Cilium agent rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/cilium image.
+version: "1.16.3"
+license: Apache-2.0
+
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
+  INITSYSTEM: "SYSTEMD"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-dbg
+    override: replace
+    startup: enabled
+
+parts:
+  bazelisk:
+    plugin: nil
+    build-packages:
+      - wget
+    overlay-script: |
+      wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-$CRAFT_ARCH_BUILD_FOR
+      mv bazelisk-linux-$CRAFT_ARCH_BUILD_FOR /usr/bin/bazelisk
+      chmod +x /usr/bin/bazelisk
+      ln -sf /usr/bin/bazelisk /usr/bin/bazel
+
+  cilium-envoy:
+    after: [bazelisk]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/proxy.git
+    source-tag: v1.29
+    source-depth: 1
+    build-packages:
+      - autoconf
+      - automake
+      - cmake
+      - coreutils
+      - curl
+      - git
+      - libtool
+      - make
+      - ninja-build
+      - patch
+      - patchelf
+      - python3
+      - python-is-python3
+      - unzip
+      - virtualenv
+      - wget
+      - zip
+      - libc6-dev
+      - gcc
+      - binutils
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    override-build: |
+      export PKG_BUILD=1
+      export DESTDIR=$CRAFT_PART_INSTALL
+      # Workaround for bazel python plugin/bits to ignore running as root
+      sed -i -e 's/envoy_dependencies_extra()/envoy_dependencies_extra(ignore_root_user_error=True)/g' WORKSPACE
+
+      make -C proxylib all
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so /usr/lib/
+      git rev-parse HEAD >SOURCE_VERSION
+      make bazel-bin/cilium-envoy
+      make install
+      rm -rf /root/.cache/bazel
+
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      - go/1.22/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+
+  debug-wrapper:
+    after: [build-deps, builder-img-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.16.3
+    source-depth: 1
+    source-subdir: images/builder
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      cd $CRAFT_PART_SRC_WORK
+      go install github.com/go-delve/delve/cmd/dlv@latest
+      go install -ldflags "-s -w" debug-wrapper.go
+
+  protoc:
+    plugin: cmake
+    source-type: git
+    source: https://github.com/protocolbuffers/protobuf.git
+    source-tag: v28.2
+    source-depth: 1
+    source-submodules:
+      - third_party/googletest
+      - third_party/abseil-cpp
+      - third_party/jsoncpp
+    cmake-generator: Ninja
+    build-packages:
+      - g++
+      - git
+    override-build: |
+      cmake $CRAFT_PART_SRC -G Ninja \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_INSTALL_PREFIX="$CRAFT_PART_INSTALL/usr/local"
+      ninja install
+    stage:
+    - -usr/local/lib
+    - -usr/local/include/absl
+    - -usr/local/include/utf8_range.h
+    - -usr/local/include/utf8_validity.h
+
+  protoplugins:
+    plugin: go
+    source: ""
+    override-build: |
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@1adbea267b837660726952ed6711b348dee87aa5
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.1
+      go install github.com/mfridman/protoc-gen-go-json@v1.4.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - jq
+      - bash-completion
+      - iproute2
+      - ipset
+      - kmod
+      - ca-certificates
+      - libz3-dev
+
+  iptables:
+    plugin: nil
+    stage-packages:
+      - iptables
+
+  iptables-wrapper:
+    after: [iptables]
+    plugin: nil
+    source-type: file
+    source: ./iptables-wrapper-installer.sh
+    build-environment:
+    - OVERRIDE_PATH: "$CRAFT_PRIME/usr/sbin"
+    - OVERRIDE_SBIN: "/usr/sbin"
+    - OVERRIDE_ALTSTYLE: "none"
+    override-prime: |
+      craftctl default
+      $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
+
+  bpftool:
+    plugin: make
+    source-type: git
+    source: https://github.com/libbpf/bpftool.git
+    source-tag: v7.4.0
+    source-depth: 1
+    source-subdir: src
+    source-submodules:
+      - "libbpf"
+    build-packages:
+      - xz-utils
+      - libzstd-dev
+      - zlib1g-dev
+      - libelf-dev
+      - libiberty-dev
+      - llvm-17
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    build-environment:
+      - EXTRA_CFLAGS: --static
+      - LLVM_CONFIG: "/usr/bin/llvm-config-17"
+      - LLVM_STRIP: "/usr/bin/llvm-strip-17"
+    override-build: |
+      # libelf requires zstd on Ubuntu 24.04, this hasn't been addressed
+      # in bpftool yet.
+      sed -i 's/-lelf/-lelf -lzstd/g' src/Makefile
+
+      make -C src -j "$(nproc)"
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin/
+      cp ./src/bpftool $CRAFT_PART_INSTALL/usr/local/sbin/
+      chmod 755 $CRAFT_PART_INSTALL/usr/local/sbin/bpftool
+
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/google/gops.git
+    source-tag: v0.3.27
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      go install -ldflags "-s -w" ./...
+
+  cni-plugins:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/containernetworking/plugins.git
+    source-tag: v1.5.0
+    source-depth: 1
+    override-build: |
+      ./build_linux.sh
+      cp -r $CRAFT_PART_BUILD/bin $CRAFT_PART_INSTALL
+    stage:
+      - -bin
+    organize:
+      bin/loopback: cni/loopback
+
+  hubble:
+    after: [build-deps]
+    plugin: make
+    source-type: git
+    source: "https://github.com/cilium/hubble.git"
+    source-tag: v1.16.3
+    source-depth: 1
+    override-build: |
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/etc/bash_completion.d
+      $CRAFT_PART_INSTALL/usr/local/bin/hubble completion bash > $CRAFT_PART_INSTALL/etc/bash_completion.d/hubble
+
+  cilium:
+    after: [build-deps, builder-img-deps]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.16.3
+    build-packages:
+      - clang-17
+      - llvm-17
+    stage-packages:
+      - clang-17
+      - llvm-17
+    build-environment:
+     - DISABLE_ENVOY_INSTALLATION: 1
+     - PKG_BUILD: 1
+     - NOSTRIP: 0
+     - NOOPT: 0
+    override-build: |
+      make build-container
+      export DESTDIR=$CRAFT_PART_INSTALL
+      make install-container-binary
+      make install-bash-completion
+      make licenses-all
+
+      echo 'install_cni "/usr/bin/cilium-dbg"' >> $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/images/cilium/init-container.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/plugins/cilium-cni/cni-uninstall.sh $CRAFT_PART_INSTALL/
+
+      cp -a $CRAFT_PART_INSTALL/usr/bin/clang-17 $CRAFT_PART_INSTALL/usr/bin/clang
+      cp -a $CRAFT_PART_INSTALL/usr/bin/llc-17 $CRAFT_PART_INSTALL/usr/bin/llc
+      cp -a $CRAFT_PART_INSTALL/usr/bin/llvm-objcopy-17 $CRAFT_PART_INSTALL/usr/bin/llvm-objcopy
+    override-prime: |
+      craftctl default
+      rm -rf /root/.cache/go-build

--- a/1.16.5/cilium/rockcraft.yaml
+++ b/1.16.5/cilium/rockcraft.yaml
@@ -1,7 +1,14 @@
+# NOTE(aznashwan): this was adapted from the existing ROCK definition
+# for release v1.16.3, the outlined changes being referenced from:
+#
+# * in cilium/cilium repo: git diff tags/1.16.3 tags/1.16.5
+# * in cilium/proxy repo: git diff origin/v1.29 origin/v1.30
+# * in cilium/image-tools: <no tags to reference, just sourced from `main`>
+
 name: cilium
 summary: Cilium agent rock for the Cilium CNI.
 description: This rock is a drop in replacement for the cilium/cilium image.
-version: "1.16.3"
+version: "1.16.5"
 license: Apache-2.0
 
 base: ubuntu@24.04
@@ -21,22 +28,27 @@ services:
     startup: enabled
 
 parts:
+  # https://github.com/cilium/proxy/blob/v1.30/Dockerfile.builder#L44-L46
   bazelisk:
     plugin: nil
     build-packages:
       - wget
     overlay-script: |
-      wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-$CRAFT_ARCH_BUILD_FOR
+      # in cilium/proxy: git diff origin/v1.29 origin/v1.30 -- Dockerfile.builder
+      wget https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$CRAFT_ARCH_BUILD_FOR
       mv bazelisk-linux-$CRAFT_ARCH_BUILD_FOR /usr/bin/bazelisk
       chmod +x /usr/bin/bazelisk
       ln -sf /usr/bin/bazelisk /usr/bin/bazel
 
+  # https://github.com/cilium/proxy/blob/v1.30/Dockerfile#L17-L24
   cilium-envoy:
     after: [bazelisk]
     plugin: make
     source-type: git
     source: https://github.com/cilium/proxy.git
-    source-tag: v1.29
+    # git diff tags/1.16.3 tags/1.16.5 -- .//images/cilium/Dockerfile
+    # https://github.com/cilium/cilium/blob/v1.16.5/images/cilium/Dockerfile#L6-L9
+    source-tag: v1.30
     source-depth: 1
     build-packages:
       - autoconf
@@ -96,6 +108,7 @@ parts:
   build-deps:
     plugin: nil
     build-snaps:
+      # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/Dockerfile#L7
       - go/1.22/stable
     build-packages:
       - autoconf
@@ -105,12 +118,14 @@ parts:
       - build-essential
       - pkg-config
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/Dockerfile#L66-L70
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/build-debug-wrapper.sh
   debug-wrapper:
     after: [build-deps, builder-img-deps]
     plugin: go
     source-type: git
     source: https://github.com/cilium/cilium.git
-    source-tag: v1.16.3
+    source-tag: v1.16.5
     source-depth: 1
     source-subdir: images/builder
     build-environment:
@@ -120,11 +135,14 @@ parts:
       go install github.com/go-delve/delve/cmd/dlv@latest
       go install -ldflags "-s -w" debug-wrapper.go
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/install-protoc.sh
   protoc:
     plugin: cmake
     source-type: git
     source: https://github.com/protocolbuffers/protobuf.git
-    source-tag: v28.2
+    # git diff tags/1.16.3 tags/1.16.5 -- .//images/builder/install-protoc.sh
+    # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/install-protoc.sh#L12
+    source-tag: v29.1
     source-depth: 1
     source-submodules:
       - third_party/googletest
@@ -145,13 +163,15 @@ parts:
     - -usr/local/include/utf8_range.h
     - -usr/local/include/utf8_validity.h
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/builder/install-protoplugins.sh
   protoplugins:
     plugin: go
     source: ""
     override-build: |
       go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@1adbea267b837660726952ed6711b348dee87aa5
-      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.1
-      go install github.com/mfridman/protoc-gen-go-json@v1.4.0
+      # git diff tags/1.16.3 tags/1.16.5 -- .//images/builder/install-protoplugins.sh
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.2
+      go install github.com/mfridman/protoc-gen-go-json@v1.4.1
       go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
   runtime-img-deps:
@@ -170,10 +190,13 @@ parts:
     stage-packages:
       - iptables
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/Dockerfile#L46-L47
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/iptables-wrapper-installer.sh
   iptables-wrapper:
     after: [iptables]
     plugin: nil
     source-type: file
+    # NOTE: we maintain out own version of ./iptables-wrapper-installer.sh.
     source: ./iptables-wrapper-installer.sh
     build-environment:
     - OVERRIDE_PATH: "$CRAFT_PRIME/usr/sbin"
@@ -183,6 +206,10 @@ parts:
       craftctl default
       $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/Dockerfile#L9
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/Dockerfile#L50
+  # https://github.com/cilium/image-tools/blob/master/images/bpftool/Dockerfile#L12-L13
+  # https://github.com/cilium/image-tools/blob/master/images/bpftool/checkout-linux.sh#L11-L12
   bpftool:
     plugin: make
     source-type: git
@@ -221,10 +248,12 @@ parts:
       cp ./src/bpftool $CRAFT_PART_INSTALL/usr/local/sbin/
       chmod 755 $CRAFT_PART_INSTALL/usr/local/sbin/bpftool
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/Dockerfile#L20-L23
   gops:
     after: [build-deps]
     plugin: go
     source-type: git
+    # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/build-gops.sh#L11-L12
     source: https://github.com/google/gops.git
     source-tag: v0.3.27
     source-depth: 1
@@ -233,12 +262,15 @@ parts:
     override-build: |
       go install -ldflags "-s -w" ./...
 
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/Dockerfile#L24-L26
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/download-cni.sh#L13
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/runtime/cni-version.sh#L2
   cni-plugins:
     after: [build-deps]
     plugin: go
     source-type: git
     source: https://github.com/containernetworking/plugins.git
-    source-tag: v1.5.0
+    source-tag: v1.6.0
     source-depth: 1
     override-build: |
       ./build_linux.sh
@@ -248,12 +280,14 @@ parts:
     organize:
       bin/loopback: cni/loopback
 
-  hubble:
+  # https://github.com/cilium/cilium/blob/v1.16.5/images/cilium/Dockerfile#L43-L55
+  hubble-completion:
     after: [build-deps]
     plugin: make
     source-type: git
     source: "https://github.com/cilium/hubble.git"
-    source-tag: v1.16.3
+    # NOTE: Hubble has same release versioning scheme as Cilium itself.
+    source-tag: v1.16.5
     source-depth: 1
     override-build: |
       craftctl default
@@ -265,7 +299,7 @@ parts:
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
-    source-tag: v1.16.3
+    source-tag: v1.16.5
     build-packages:
       - clang-17
       - llvm-17

--- a/1.16.5/cilium/rockcraft.yaml
+++ b/1.16.5/cilium/rockcraft.yaml
@@ -84,6 +84,13 @@ parts:
       # Workaround for bazel python plugin/bits to ignore running as root
       sed -i -e 's/envoy_dependencies_extra()/envoy_dependencies_extra(ignore_root_user_error=True)/g' WORKSPACE
 
+      # HACK(aznashwan): there was a known bug in `google/cel-cpp`.
+      # cel-cpp is imported by `envoyproxy` itself, which is imported by `cilium/proxy`.
+      # https://github.com/envoyproxy/envoy/issues/34368
+      # https://github.com/envoyproxy/envoy/pull/36940
+      # https://github.com/envoyproxy/envoy/commit/c7d0d5a340abb34916eaea3833cf5bf85c99b31f
+      sed -i -e 's/ENVOY_SHA = ".*"/ENVOY_SHA = "c7d0d5a340abb34916eaea3833cf5bf85c99b31f"/' WORKSPACE
+
       make -C proxylib all
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/
       cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/

--- a/1.16.5/cilium/rockcraft.yaml
+++ b/1.16.5/cilium/rockcraft.yaml
@@ -81,15 +81,8 @@ parts:
     override-build: |
       export PKG_BUILD=1
       export DESTDIR=$CRAFT_PART_INSTALL
-      # Workaround for bazel python plugin/bits to ignore running as root
-      sed -i -e 's/envoy_dependencies_extra()/envoy_dependencies_extra(ignore_root_user_error=True)/g' WORKSPACE
-
-      # HACK(aznashwan): there was a known bug in `google/cel-cpp`.
-      # cel-cpp is imported by `envoyproxy` itself, which is imported by `cilium/proxy`.
-      # https://github.com/envoyproxy/envoy/issues/34368
-      # https://github.com/envoyproxy/envoy/pull/36940
-      # https://github.com/envoyproxy/envoy/commit/c7d0d5a340abb34916eaea3833cf5bf85c99b31f
-      sed -i -e 's/ENVOY_SHA = ".*"/ENVOY_SHA = "c7d0d5a340abb34916eaea3833cf5bf85c99b31f"/' WORKSPACE
+      export EMAIL=root@localhost
+      git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
 
       make -C proxylib all
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/


### PR DESCRIPTION
We're adding a rock definition for cilium 1.16.5.

In order to use recent libstdc++ releases, we need to patch cel-cpp, which isn't straight forward due to how the build process is layered, each layer patching the next one (cilium -> cilium-proxy -> envoy -> cel-cpp).