### PR TITLE
fix(ci): unpin rockcraft

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,7 +14,6 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
-      rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:


### PR DESCRIPTION
This repo’s CI is failing due to rockcraft being pinned to a specific revision, unlike our other rock repos, which track latest/stable. A breaking change in latest/stable modified the container name used for building rocks, requiring an update in our k8s-workflows repo. This PR unpins the rockcraft version, aligning it with other repos to receive updates.