### PR TITLE
Update rockcraft.yaml

### DIFF
--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -79,7 +79,7 @@ parts:
       cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/
       cp proxylib/libcilium.so /usr/lib/
       git rev-parse HEAD >SOURCE_VERSION
-      make bazel-bin/cilium-envoy
+      BAZEL_BUILD_OPTIONS="--define=wasm=disabled" make bazel-bin/cilium-envoy
       make install
       rm -rf /root/.cache/bazel
 


### PR DESCRIPTION
Disable WASM extensions as there are numerous CVE's associated with the default runtime (v8)