### PR TITLE
feat: enable FIPS support for Cilium

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,12 @@ jobs:
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
+      enabled-ubuntu-pro-features: "fips-updates"
+      multipass-image: "22.04"
+      rockcraft-revisions: '{"amd64": "3494"}'
+    secrets:
+      UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/1.17.1/cilium-operator-generic/rockcraft.yaml
+++ b/1.17.1/cilium-operator-generic/rockcraft.yaml
@@ -36,7 +36,7 @@ parts:
     plugin: nil
     build-snaps:
       # https://github.com/cilium/cilium/blob/v1.17.1/images/builder/Dockerfile#L7
-      - go/1.23/stable
+      - go/1.23-fips/stable
     build-packages:
       - autoconf
       - automake
@@ -110,7 +110,9 @@ parts:
     # https://github.com/cilium/cilium/blob/v1.17.1/images/runtime/build-gops.sh#L11-L12
     source-tag: v0.3.27
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
     override-build: |
       go install -ldflags "-s -w" ./...
 

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -4,8 +4,8 @@ description: This rock is a drop in replacement for the cilium/cilium image.
 version: "1.17.1"
 license: Apache-2.0
 
-base: ubuntu@24.04
-build-base: ubuntu@24.04
+base: ubuntu@22.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:
@@ -14,15 +14,21 @@ package-repositories:
   - type: apt
     formats: [deb-src]
     components: [main restricted universe multiverse]
-    suites: [noble, noble-updates]
+    suites: [jammy, jammy-updates]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     url: http://archive.ubuntu.com/ubuntu
   - type: apt
     formats: [deb-src]
     components: [main restricted universe multiverse]
-    suites: [noble-security]
+    suites: [jammy-security]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     url: http://security.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb, deb-src]
+    components: [main]
+    suites: [llvm-toolchain-jammy-17]
+    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
+    url: http://apt.llvm.org/jammy/
 
 environment:
   HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
@@ -113,7 +119,7 @@ parts:
     plugin: nil
     build-snaps:
       # https://github.com/cilium/cilium/blob/v1.17.1/images/builder/Dockerfile#L7
-      - go/1.23/stable
+      - go/1.23-fips/stable
     build-packages:
       - autoconf
       - automake
@@ -163,7 +169,7 @@ parts:
     - OVERRIDE_ALTSTYLE: "none"
     override-prime: |
       craftctl default
-      $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
+      bash $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
 
   # https://github.com/cilium/cilium/blob/v1.17.1/images/runtime/Dockerfile#L9
   # https://github.com/cilium/cilium/blob/v1.17.1/images/runtime/Dockerfile#L50
@@ -218,7 +224,9 @@ parts:
     source-tag: v0.3.27
     source-depth: 1
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
     override-build: |
       go install -ldflags "-s -w" ./...
 
@@ -232,6 +240,10 @@ parts:
     source: https://github.com/containernetworking/plugins.git
     source-tag: v1.6.0
     source-depth: 1
+    build-environment:
+      - CGO_ENABLED: 1
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
     override-build: |
       ./build_linux.sh
       strip $CRAFT_PART_BUILD/bin/loopback
@@ -266,12 +278,20 @@ parts:
       - llvm-17
     build-environment:
      - DISABLE_ENVOY_INSTALLATION: 1
+     - CGO_ENABLED: 1
+     - GOTOOLCHAIN: local
+     - GOEXPERIMENT: opensslcrypto
      - PKG_BUILD: 1
      - NOSTRIP: 0
      - NOOPT: 0
     override-build: |
-      make build-container
       export DESTDIR=$CRAFT_PART_INSTALL
+
+      # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
+      find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
+
+      make build-container
+
       make install-container-binary
       make install-bash-completion
       make licenses-all
@@ -300,7 +320,7 @@ parts:
       cp -r llvm-toolchain-17-*/. $CRAFT_PART_SRC
     override-build: |
       apt-get build-dep -y llvm-toolchain-17
-      
+
       mkdir -p llvm/build-native
       cd llvm/build-native
 

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,116 @@
+# Cilium FIPS Compliance Analysis
+
+The following document summarizes the current state of [FIPS 140-3] compliance
+for Cilium CNI, focusing on its cryptographic components and build
+requirements. This overview is intended to guide users and developers in
+understanding the compliance status and necessary steps for achieving FIPS mode
+operation.
+
+## Glossary
+
+This document uses a set of abbreviations and technical concepts which are
+explained below:
+
+- **Federal Information Processing Standards (FIPS)**: A set of standards for
+cryptographic modules published by the U.S. government.
+- **Container Network Interface (CNI)**: A networking framework for Linux
+containers and orchestration platforms like Kubernetes.
+- **Transport Layer Security (TLS)**: A cryptographic protocol designed to
+provide secure communication over a computer network.
+- **Internet Protocol Security (IPsec)**: A secure network protocol suite that
+authenticates and encrypts packets of data to provide secure encrypted
+communication.
+- **WireGuard**: A modern VPN protocol that uses state of the art cryptography
+for secure tunneling.
+- **Extended Berkeley Packet Filter (eBPF)**: A kernel technology that allows
+programs to run in kernel space without changing kernel source code.
+- **Envoy Proxy**: An L7 proxy and communication bus designed for large modern
+service oriented architectures.
+
+## Cryptographic Implementation Analysis
+
+Cilium's cryptographic footprint encompasses multiple areas including
+transparent encryption, TLS inspection, certificate management, and secure
+communication with the Kubernetes API. The primary cryptographic usage involves
+IPsec/WireGuard encryption, TLS termination and inspection, and API
+authentication. FIPS compliance depends on the cryptographic libraries, Go
+runtime, and build environment used for these components.
+
+> **_NOTE:_** As of 2025-07-29, WireGuard has limited FIPS support due to ChaCha20Poly1305
+> algorithm.
+
+### Cilium Agent Component
+
+The Cilium agent is the core component running on each cluster node,
+responsible for enforcing network policies, managing encryption, and handling
+network connectivity. Its cryptographic usage includes:
+
+- **Transparent Encryption**: [IPsec] or [WireGuard] encryption for pod-to-pod
+communication.
+- **TLS Communication**: Secure communication with the Kubernetes API server
+using Go's crypto packages.
+- **Certificate Management**: Handling TLS certificates for L7 proxy
+functionality.
+- **Key Management**: IPsec key rotation and distribution via Kubernetes
+secrets.
+
+### Cilium Operator Component
+
+The operator component manages cluster-wide operations and coordination. Its
+cryptographic involvement includes:
+
+- **TLS for Kubernetes API**: Certificate validation and secure API
+communication.
+- **Secret Synchronization**: Managing and distributing cryptographic secrets
+across the cluster.
+- **Certificate Lifecycle**: Managing certificates for various Cilium features.
+
+### Envoy Proxy Integration
+
+Cilium utilizes Envoy proxy for L7 policy enforcement and [TLS inspection]
+capabilities:
+
+- **TLS Termination**: Terminating TLS connections for inspection and policy
+enforcement
+- **Certificate Handling**: Managing certificates via Secret Discovery Service
+(SDS) or Network Policy Discovery Service (NPDS)
+- **Cryptographic Processing**: TLS handshakes and certificate validation
+
+## FIPS Compliance Status
+
+### Implementation Dependencies
+
+Cilium's FIPS compliance depends on several key components:
+
+1. **Go Runtime**: Cilium is written in Go and relies on Go's cryptographic
+packages. A modified [Go toolchain from Microsoft] must be used.
+2. **OpenSSL**: Cilium must link against a FIPS-validated OpenSSL
+implementation. Currently, there is no FIPS base for Rocks, so it must be
+sourced, for example, from `core22/fips`.
+3. **Build Environment**: The build process must be performed on a Ubuntu Pro
+machine (details provided below).
+
+### Required Build Modifications
+
+To build Cilium in FIPS-compliant mode, the following requirements must be met:
+
+1. **Prerequisites**:
+   - Ubuntu Pro enabled machine
+   - FIPS **must NOT** enabled
+   - Rockcraft installed from the `edge/pro-sources` channel (refer to this
+   Discourse [post][discourse post])
+
+2. **Building the Image**:
+  Use the following command to build the image:
+   ```bash
+   sudo rockcraft pack --pro=fips-updates
+   ```
+
+<!-- LINKS -->
+
+[discourse post]: https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+[FIPS 140-3]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-3.pdf
+[Go toolchain from Microsoft]: https://github.com/microsoft/go/blob/microsoft/release-branch.go1.23/eng/doc/fips/README.md
+[IPsec]: https://docs.cilium.io/en/latest/security/network/encryption-ipsec/
+[WireGuard]: https://docs.cilium.io/en/latest/security/network/encryption-wireguard/
+[TLS inspection]: https://docs.cilium.io/en/latest/security/tls-visibility/


### PR DESCRIPTION
## Overview
This pull request introduces changes to support FIPS compliance for Cilium, including updates to build configurations, environment settings, and documentation.
### Build Configuration Updates for FIPS Compliance:
* Updated platform labels to include FIPS-related settings, added `enabled-ubuntu-pro-features` for FIPS updates, and introduced the shared secret (`UBUNTU_PRO_TOKEN`) for Ubuntu Pro integration.
* Changed the `1.17.1` Rock to use `go/1.23-fips/stable`, updated build environments to enable `CGO_ENABLED`, `GOTOOLCHAIN: local`, and `GOEXPERIMENT: opensslcrypto`, and patched Makefiles for FIPS-compatible flags.

### Environment and Package Repository Adjustments:
* Downgraded base and build-base versions from Ubuntu 24.04 to 22.04, updated package repositories to use `jammy` suites, and added a repository for LLVM toolchain. 
### Documentation for FIPS Compliance:
* Added a document detailing Cilium's FIPS compliance analysis, including cryptographic implementation, dependencies, and steps for building FIPS-compliant images.