### PR TITLE
ci: Include FIPS OpenSSL in the rock

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,9 +10,6 @@ jobs:
     name: Build Rocks and Push Arch Specific Images
     uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
     with:
-      multipass-cpus: 8
-      multipass-memory: 16GB
-      multipass-disk: 60GB
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
@@ -20,8 +17,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64", "amd64"]'
       platform-labels: '{"arm64": ["self-hosted", "linux", "arm64", "jammy", "xlarge"], "amd64": ["self-hosted", "linux", "amd64", "jammy", "xlarge"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      multipass-image: "22.04"
-      rockcraft-revisions: '{"amd64": "3494"}'
+      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   scan-images:

--- a/1.17.1/cilium-operator-generic/rockcraft.yaml
+++ b/1.17.1/cilium-operator-generic/rockcraft.yaml
@@ -116,6 +116,13 @@ parts:
     override-build: |
       go install -ldflags "-s -w" ./...
 
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
   # https://github.com/cilium/cilium/blob/v1.17.1/images/operator/Dockerfile
   # https://github.com/cilium/cilium/blob/v1.17.1/Makefile#L65-L66
   cilium-operator:

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -267,6 +267,13 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/etc/bash_completion.d
       $CRAFT_PART_INSTALL/usr/local/bin/hubble completion bash > $CRAFT_PART_INSTALL/etc/bash_completion.d/hubble
 
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
   cilium:
     after: [build-deps, builder-img-deps]
     plugin: make


### PR DESCRIPTION
### Overview

This PR builds on top of https://github.com/canonical/k8s-workflows/pull/50 and discards multipass as the build environment. Also enables building FIPS-enabled rocks on ARM and only includes OpenSSL from FIPS sources rather than the full core22.