### PR TITLE
fix: use external linker with core22 rpath

### DIFF
--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -4,6 +4,9 @@ description: This rock is a drop in replacement for the cilium/cilium image.
 version: "1.17.1"
 license: Apache-2.0
 
+# Note(Reza): We are hardcoding the dynamic libraries path inside the cilium 
+# part binaries. Change them and also the LD_LIBRARY_PATH in the wrapper codebase 
+# accodingly when you change the base snap.
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 platforms:
@@ -36,7 +39,7 @@ environment:
 
 services:
   cilium:
-    command: /snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/bin/cilium-dbg
+    command: /usr/bin/cilium-dbg
     override: replace
     startup: enabled
 

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -278,11 +278,11 @@ parts:
       - openssl # now automatically selected from fips-preview
 
   wrapper:
-        plugin: dump
-        source: .
-        source-type: local
-        stage:
-        - wrapper
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+    - wrapper
   
   cilium:
     after: [build-deps, builder-img-deps, wrapper]
@@ -304,17 +304,29 @@ parts:
     override-build: |
       export DESTDIR=$CRAFT_PART_INSTALL
 
+      export LIBRARY_PATH=/snap/core22/current/usr/lib/x86_64-linux-gnu
+      export DYNAMIC_LINKER_PATH=/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        export LIBRARY_PATH=/snap/core22/current/usr/lib/aarch64-linux-gnu
+        export DYNAMIC_LINKER_PATH=/snap/core22/current/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
+      fi
+
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
       make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool'
-      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
+      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
 
-      # NOTE(reza): build a wrapper binary around cilium-sysctlfix to set the correct LD_LIBRARY_PATH at runtime
+      # NOTE(reza): build a wrapper binary around cilium-sysctlfix and cilium-cni to set the correct LD_LIBRARY_PATH at runtime
       cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
-      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/wrapper
+      mkdir -p $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/wrapper/bin
 
-      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix -ldflags "-X main.binaryName=cilium-sysctlfix -X main.ldLibraryPath=${LIBRARY_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni -ldflags "-X main.binaryName=cilium-cni -X main.ldLibraryPath=${LIBRARY_PATH}" wrapper/main.go
+
 
       make install-container-binary
       make install-bash-completion

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -348,10 +348,15 @@ parts:
   symlink-ld:
     plugin: nil
     override-build: |
-      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu
-      ln -sf /lib64/ld-linux-x86-64.so.2 \
-        ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
-
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/aarch64-linux-gnu
+        ln -sf /lib/ld-linux-aarch64.so.1 \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
+      else 
+        mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu
+        ln -sf /lib64/ld-linux-x86-64.so.2 \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+      fi
   llvm:
     plugin: nil
     build-packages:

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -274,8 +274,15 @@ parts:
       - openssl-fips-module-3 # a Pro only FIPS package for openssl
       - openssl # now automatically selected from fips-preview
 
+  wrapper:
+        plugin: dump
+        source: .
+        source-type: local
+        stage:
+        - wrapper
+  
   cilium:
-    after: [build-deps, builder-img-deps]
+    after: [build-deps, builder-img-deps, wrapper]
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
@@ -298,8 +305,13 @@ parts:
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
       make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool plugins/cilium-cni'
-      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
-      make build-container SUBDIRS_CILIUM_CONTAINER='tools/sysctlfix' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu -Wl,--disable-new-dtags"'
+      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount tools/sysctlfix' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
+
+      # NOTE(reza): build a wrapper binary around cilium-sysctlfix to set the correct LD_LIBRARY_PATH at runtime
+      cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/wrapper
+
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix wrapper/main.go
 
       make install-container-binary
       make install-bash-completion

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -307,8 +307,8 @@ parts:
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool plugins/cilium-cni'
-      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount tools/sysctlfix' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool'
+      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
 
       # NOTE(reza): build a wrapper binary around cilium-sysctlfix to set the correct LD_LIBRARY_PATH at runtime
       cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -297,8 +297,9 @@ parts:
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon tools/sysctlfix cilium-health bugtool plugins/cilium-cni'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool plugins/cilium-cni'
       make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
+      make build-container SUBDIRS_CILIUM_CONTAINER='tools/sysctlfix'
 
       make install-container-binary
       make install-bash-completion

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -299,7 +299,7 @@ parts:
 
       make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool plugins/cilium-cni'
       make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
-      make build-container SUBDIRS_CILIUM_CONTAINER='tools/sysctlfix'
+      make build-container SUBDIRS_CILIUM_CONTAINER='tools/sysctlfix' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu -Wl,--disable-new-dtags"'
 
       make install-container-binary
       make install-bash-completion

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -297,7 +297,7 @@ parts:
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      make build-container GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
+      make build-container GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu -lpthread"'
 
       make install-container-binary
       make install-bash-completion

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -36,7 +36,7 @@ environment:
 
 services:
   cilium:
-    command: /usr/bin/cilium-dbg
+    command: /snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/bin/cilium-dbg
     override: replace
     startup: enabled
 
@@ -297,7 +297,7 @@ parts:
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      make build-container
+      make build-container GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
 
       make install-container-binary
       make install-bash-completion
@@ -314,6 +314,13 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
+
+  symlink-ld:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu
+      ln -sf /lib64/ld-linux-x86-64.so.2 \
+        ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
 
   llvm:
     plugin: nil

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -297,7 +297,8 @@ parts:
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      make build-container GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu -lpthread"'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon tools/sysctlfix cilium-health bugtool plugins/cilium-cni'
+      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 -Wl,-rpath,/snap/core22/current/usr/lib/x86_64-linux-gnu"'
 
       make install-container-binary
       make install-bash-completion
@@ -314,13 +315,6 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
-
-  symlink-ld:
-    plugin: nil
-    override-build: |
-      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu
-      ln -sf /lib64/ld-linux-x86-64.so.2 \
-        ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
 
   llvm:
     plugin: nil

--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -315,17 +315,18 @@ parts:
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg daemon cilium-health bugtool'
-      make build-container SUBDIRS_CILIUM_CONTAINER='tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
+      make build-container SUBDIRS_CILIUM_CONTAINER='daemon cilium-health bugtool'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
 
       # NOTE(reza): build a wrapper binary around cilium-sysctlfix and cilium-cni to set the correct LD_LIBRARY_PATH at runtime
       cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
       mkdir -p $CRAFT_PART_BUILD/wrapper/bin
-      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/wrapper/bin
-      cp $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg $CRAFT_PART_BUILD/wrapper/bin
+
 
       CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix -ldflags "-X main.binaryName=cilium-sysctlfix -X main.ldLibraryPath=${LIBRARY_PATH}" wrapper/main.go
       CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni -ldflags "-X main.binaryName=cilium-cni -X main.ldLibraryPath=${LIBRARY_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg -ldflags "-X main.binaryName=cilium-dbg -X main.ldLibraryPath=${LIBRARY_PATH}" wrapper/main.go
 
 
       make install-container-binary
@@ -343,6 +344,13 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
+
+  symlink-ld:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu
+      ln -sf /lib64/ld-linux-x86-64.so.2 \
+        ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
 
   llvm:
     plugin: nil

--- a/1.17.1/cilium/wrapper/README.md
+++ b/1.17.1/cilium/wrapper/README.md
@@ -1,0 +1,16 @@
+## Wrapper binary with LD_LIBRARY_PATH set
+
+This software provides a wrapper around an arbitrary binary, ensuring it always runs with a fixed
+LD_LIBRARY_PATH environment variable set at runtime. Both the target binary and the value of
+LD_LIBRARY_PATH must be provided at build time:
+
+```
+go build -o wrapper-bin -ldflags "-X main.binaryName=<BINARY_NAME> -X main.ldLibraryPath=<LD_LIBRARY_PATH>" main.go
+```
+
+This is needed for the Cilium rock image since the Cilium binaries are built with
+dynamic linking and may sometimes run outside the namespaces of their container.
+While setting RPATH works for direct dependencies, indirect dependencies are not resolved correctly.
+This wrapper ensures all dynamic links resolve to the correct libraries. 
+
+

--- a/1.17.1/cilium/wrapper/go.mod
+++ b/1.17.1/cilium/wrapper/go.mod
@@ -1,3 +1,3 @@
-module sample/wrapper
+module github.com/canonical/cilium-rocks/wrapper
 
 go 1.24.6

--- a/1.17.1/cilium/wrapper/go.mod
+++ b/1.17.1/cilium/wrapper/go.mod
@@ -1,0 +1,3 @@
+module sample/wrapper
+
+go 1.24.6

--- a/1.17.1/cilium/wrapper/main.go
+++ b/1.17.1/cilium/wrapper/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+//go:embed cilium-sysctlfix
+var embeddedBinary []byte
+
+func main() {
+
+	tmpDir := os.TempDir()
+	binPath := filepath.Join(tmpDir, "wrapped-binary")
+
+	err := os.WriteFile(binPath, embeddedBinary, 0755)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write embedded binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Prepare command with custom environment variables
+	cmd := exec.Command(binPath, os.Args[1:]...)
+	cmd.Env = append(os.Environ(),
+		"LD_LIBRARY_PATH=/snap/core22/current/usr/lib/x86_64-linux-gnu",
+	)
+
+	// Connect stdin/stdout/stderr to this process
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the binary
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%w", err)
+		os.Exit(1)
+	}
+}

--- a/1.17.1/cilium/wrapper/main.go
+++ b/1.17.1/cilium/wrapper/main.go
@@ -39,7 +39,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := os.Chmod(f.Name(), 0755); err != nil {
+	if err := os.Chmod(f.Name(), 0700); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to close the embedded binary: %v\n", err)
 		os.Exit(1)
 	}
@@ -57,7 +57,11 @@ func main() {
 
 	// Run the binary
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%w", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ProcessState.ExitCode())
+		} else {
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
The Cilium agent pod has an init-container named `mount-cgroup` that copies the `cilium-mount` binary from the Cilium image to the host path and then tries to execute it from the host namespace. 
```
- command:
    - sh
    - -ec
    - |
      cp /usr/bin/cilium-mount /hostbin/cilium-mount;
      nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
      rm /hostbin/cilium-mount
    env:
    - name: CGROUP_ROOT
      value: /run/cilium/cgroupv2
    - name: BIN_PATH
      value: /opt/cni/bin
    image: ghcr.io/canonical/cilium:1.17.1-ck3
    imagePullPolicy: IfNotPresent
    name: mount-cgroup
    resources: {}
    securityContext:
      capabilities:
        add:
        - SYS_ADMIN
        - SYS_CHROOT
        - SYS_PTRACE
        drop:
        - ALL
      seLinuxOptions:
        level: s0
        type: spc_t
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: FallbackToLogsOnError
    volumeMounts:
    - mountPath: /hostproc
      name: hostproc
    - mountPath: /hostbin
      name: cni-path
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-jrqbt
      readOnly: true

```
Since we are using dynamic linking to enable FIPS, the copied binary can only reach out to standard shared libraries of the host, which may be missing or incompatible (e.g. in Ubuntu 20.04)
This PR adds custom `rpath` directories in the build process so that the binary can use correct libraries. 