### PR TITLE
Add Cilium 1.18.4

### DIFF
--- a/1.18.4/cilium-operator-generic/rockcraft.yaml
+++ b/1.18.4/cilium-operator-generic/rockcraft.yaml
@@ -1,0 +1,163 @@
+name: cilium-operator-generic
+summary: Cilium operator rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/operator-generic image.
+version: "1.18.4"
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  GOPS_CONFIG_DIR: "/"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-operator-generic
+    override: replace
+    startup: enabled
+
+parts:
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/Dockerfile#L7
+      - go/1.24-fips/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/Dockerfile#L66-L70
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/build-debug-wrapper.sh
+  debug-wrapper:
+    after: [build-deps, builder-img-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.18.4
+    source-subdir: images/builder
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      cd $CRAFT_PART_SRC_WORK
+      go install github.com/go-delve/delve/cmd/dlv@latest
+      go install -ldflags "-s -w" debug-wrapper.go
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/install-protoc.sh
+  protoc:
+    plugin: cmake
+    source-type: git
+    source: https://github.com/protocolbuffers/protobuf.git
+    source-tag: v33.0
+    source-submodules:
+      - third_party/googletest
+      - third_party/abseil-cpp
+      - third_party/jsoncpp
+    cmake-generator: Ninja
+    build-packages:
+      - g++
+      - git
+    override-build: |
+      cmake $CRAFT_PART_SRC -G Ninja \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_INSTALL_PREFIX="$CRAFT_PART_INSTALL/usr/local"
+      ninja install
+    stage:
+    - -usr/local/lib
+    - -usr/local/include/absl
+    - -usr/local/include/utf8_range.h
+    - -usr/local/include/utf8_validity.h
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/install-protoplugins.sh
+  protoplugins:
+    plugin: go
+    source: ""
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+      
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.10
+      go install github.com/mfridman/protoc-gen-go-json@v1.5.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - ca-certificates
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/operator/Dockerfile#L69-L75
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/google/gops.git
+    # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/build-gops.sh#L11-L12
+    source-tag: v0.3.27
+    build-environment:
+      - CGO_ENABLED: 1
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
+      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      go install -ldflags "-s -w" ./...
+
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/operator/Dockerfile
+  # https://github.com/cilium/cilium/blob/v1.18.4/Makefile#L65-L66
+  cilium-operator:
+    after: [build-deps, builder-img-deps]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.18.4
+    build-environment:
+     - CGO_ENABLED: "1"
+     - GOTOOLCHAIN: local
+     - GOEXPERIMENT: opensslcrypto
+     - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+     - GO_BUILD_LDFLAGS: "-linkmode external"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
+      find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
+
+      export VARIANT="generic"
+      make build-container-operator-$VARIANT
+      export DESTDIR=$CRAFT_PART_INSTALL
+      make install-container-binary-operator-$VARIANT
+      make licenses-all
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/

--- a/1.18.4/cilium/envoy-fixes.patch
+++ b/1.18.4/cilium/envoy-fixes.patch
@@ -1,0 +1,25 @@
+From 7f2e2b47b7c13f4c7bf0cf5a61b1e7981579dce5 Mon Sep 17 00:00:00 2001
+From: rapour <reza.abbasalipour@canonical.com>
+Date: Wed, 29 Oct 2025 18:30:45 +0400
+Subject: [PATCH] fix ignore_root_user_error
+
+Signed-off-by: rapour <reza.abbasalipour@canonical.com>
+---
+ WORKSPACE | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index 6439f904..f7003252 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -77,7 +77,7 @@ envoy_dependencies()
+ 
+ load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+ 
+-envoy_dependencies_extra()
++envoy_dependencies_extra(ignore_root_user_error=True)
+ 
+ load("@envoy//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+ 
+-- 
+2.43.0

--- a/1.18.4/cilium/iptables-wrapper-installer.sh
+++ b/1.18.4/cilium/iptables-wrapper-installer.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+# https://github.com/kubernetes-sigs/iptables-wrappers/blob/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eux
+
+# Find iptables binary location
+if [ -n "$OVERRIDE_SBIN" ]; then
+    sbin="$OVERRIDE_SBIN"
+elif [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+if [ -n "$OVERRIDE_PATH" ]; then
+    target="$OVERRIDE_PATH"
+else
+    target="$sbin"
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -n "$OVERRIDE_ALTSTYLE" ]; then
+    altstyle="$OVERRIDE_ALTSTYLE"
+elif [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[0123]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.4 or newer." 1>&2
+        exit 1
+        ;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${target}/iptables-wrapper"
+cat > "${target}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${target}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${target}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${target}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${target}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -377,7 +377,6 @@ parts:
           -DLLVM_TARGETS_TO_BUILD="BPF" \
           -DLLVM_ENABLE_PROJECTS="clang" \
           -DBUILD_SHARED_LIBS="OFF" \
-          -DLLVM_BUILD_STATIC="OFF" \
           -DCMAKE_CXX_FLAGS="-s -flto" \
           -DCMAKE_BUILD_TYPE="Release" \
           -DLLVM_BUILD_RUNTIME="OFF" \

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -1,0 +1,394 @@
+name: cilium
+summary: Cilium agent rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/cilium image.
+version: "1.18.4"
+license: Apache-2.0
+
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+package-repositories:
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy, jammy-updates]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://archive.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy-security]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://security.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb, deb-src]
+    components: [main]
+    suites: [llvm-toolchain-jammy-17 llvm-toolchain-jammy-19]
+    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
+    url: http://apt.llvm.org/jammy/
+
+environment:
+  HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
+  INITSYSTEM: "SYSTEMD"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-dbg
+    override: replace
+    startup: enabled
+
+parts:
+  # https://github.com/cilium/proxy/blob/v1.34/Dockerfile.builder#L44-L46
+  bazelisk:
+    plugin: nil
+    build-packages:
+      - wget
+    overlay-script: |
+      wget https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-$CRAFT_ARCH_BUILD_FOR
+      mv bazelisk-linux-$CRAFT_ARCH_BUILD_FOR /usr/bin/bazelisk
+      chmod +x /usr/bin/bazelisk
+      ln -sf /usr/bin/bazelisk /usr/bin/bazel
+
+  # https://github.com/cilium/proxy/blob/v1.34/Dockerfile#L17-L24
+  cilium-envoy:
+    after: [bazelisk]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/proxy.git
+    source-tag: v1.34
+    source-depth: 1
+    build-packages:
+      - autoconf
+      - automake
+      - cmake
+      - coreutils
+      - curl
+      - git
+      - libtool
+      - make
+      - ninja-build
+      - patch
+      - patchelf
+      - python3
+      - python-is-python3
+      - unzip
+      - virtualenv
+      - wget
+      - zip
+      - libc6-dev
+      - gcc
+      - binutils
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    override-build: |
+      export PKG_BUILD=1
+      export DESTDIR=$CRAFT_PART_INSTALL
+      export EMAIL=root@localhost
+      git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
+
+      make -C proxylib all
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so /usr/lib/
+      git rev-parse HEAD >SOURCE_VERSION
+      make bazel-bin/cilium-envoy
+      make install
+      rm -rf /root/.cache/bazel
+
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+      - ccache
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/Dockerfile#L7
+      - go/1.24-fips/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+      # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/install-protoc.sh
+      - protobuf-compiler
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/builder/install-protoplugins.sh
+  protoplugins:
+    plugin: nil
+    overlay-script: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.10
+      go install github.com/mfridman/protoc-gen-go-json@v1.5.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - bash-completion
+      - iproute2
+      - ipset
+      - kmod
+      - ca-certificates
+
+  iptables:
+    plugin: nil
+    stage-packages:
+      - iptables
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/Dockerfile#L46-L47
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/iptables-wrapper-installer.sh
+  iptables-wrapper:
+    after: [iptables]
+    plugin: nil
+    source-type: file
+    # NOTE: we maintain out own version of ./iptables-wrapper-installer.sh.
+    source: ./iptables-wrapper-installer.sh
+    build-environment:
+    - OVERRIDE_PATH: "$CRAFT_PRIME/usr/sbin"
+    - OVERRIDE_SBIN: "/usr/sbin"
+    - OVERRIDE_ALTSTYLE: "none"
+    override-prime: |
+      craftctl default
+      bash $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/Dockerfile#L9
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/Dockerfile#L50
+  # https://github.com/cilium/image-tools/blob/master/images/bpftool/Dockerfile#L12-L13
+  bpftool:
+    plugin: make
+    source-type: git
+    source: https://github.com/libbpf/bpftool.git
+    source-tag: v7.4.0
+    source-depth: 1
+    source-subdir: src
+    source-submodules:
+      - "libbpf"
+    build-packages:
+      - xz-utils
+      - libzstd-dev
+      - zlib1g-dev
+      - libelf-dev
+      - libiberty-dev
+      - llvm-17
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    build-environment:
+      - EXTRA_CFLAGS: --static
+      - LLVM_CONFIG: "/usr/bin/llvm-config-17"
+      - LLVM_STRIP: "/usr/bin/llvm-strip-17"
+    override-build: |
+      # libelf requires zstd on Ubuntu 24.04, this hasn't been addressed
+      # in bpftool yet.
+      sed -i 's/-lelf/-lelf -lzstd/g' src/Makefile
+
+      make -C src -j "$(nproc)"
+      strip src/bpftool
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin/
+      cp ./src/bpftool $CRAFT_PART_INSTALL/usr/local/sbin/
+      chmod 755 $CRAFT_PART_INSTALL/usr/local/sbin/bpftool
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/Dockerfile#L20-L23
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/build-gops.sh#L11-L12
+    source: https://github.com/google/gops.git
+    source-tag: v0.3.27
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: "1"
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
+      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      go install -ldflags "-s -w" ./...
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/Dockerfile#L24-L26
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/download-cni.sh#L13
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/runtime/cni-version.sh#L2
+  cni-plugins:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/containernetworking/plugins.git
+    source-tag: v1.8.0
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: "1"
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
+      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      ./build_linux.sh
+      strip $CRAFT_PART_BUILD/bin/loopback
+      cp -r $CRAFT_PART_BUILD/bin $CRAFT_PART_INSTALL
+    stage:
+      - -bin
+    organize:
+      bin/loopback: cni/loopback
+
+  # https://github.com/cilium/cilium/blob/v1.18.4/images/cilium/Dockerfile#L45-L57
+  hubble-completion:
+    after: [build-deps]
+    plugin: make
+    source-type: git
+    source: "https://github.com/cilium/hubble.git"
+    # NOTE: Hubble has same release versioning scheme as Cilium itself.
+    # The Hubble CLI is backward compatible with all supported Cilium releases.
+    # For this reason, only the latest Hubble CLI version is maintained.
+    source-tag: v1.18.3
+    source-depth: 1
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/etc/bash_completion.d
+      $CRAFT_PART_INSTALL/usr/local/bin/hubble completion bash > $CRAFT_PART_INSTALL/etc/bash_completion.d/hubble
+
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
+  zig:
+    plugin: nil
+    build-packages:
+      - tar
+      - curl
+    override-build: |
+      ARCH=x86_64
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        ARCH=aarch64
+      fi
+
+      curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
+      mkdir -p /zig
+      tar --strip-components 1 -xf zig.tar.xz -C /zig
+
+      ln -sf /zig/zig /usr/bin/zig
+  
+  cilium:
+    after: [build-deps, builder-img-deps, zig]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.18.4
+    build-packages:
+      - clang-17
+      - llvm-17
+    build-environment:
+     - DISABLE_ENVOY_INSTALLATION: "1"
+     - CGO_ENABLED: "1"
+     - GOTOOLCHAIN: local
+     - GOEXPERIMENT: opensslcrypto
+     - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+     - GO_BUILD_LDFLAGS: "-linkmode external"
+     - PKG_BUILD: "1"
+     - NOSTRIP: "0"
+     - NOOPT: "0"
+    override-build: |
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+      
+      # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
+      find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
+
+      # Note(Reza): The target must match the glibc version corresponding to the oldest supported host.
+      CXX="zig c++ -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" CC="zig cc -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" make build-container
+
+      make install-container-binary
+      make install-bash-completion
+      make licenses-all
+
+      echo 'install_cni "/usr/bin/cilium-dbg"' >> $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/images/cilium/init-container.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/plugins/cilium-cni/cni-uninstall.sh $CRAFT_PART_INSTALL/
+
+      find $CRAFT_PART_INSTALL -type f -executable -exec sh -c 'objcopy --strip-all ${0}' {} \;
+    override-prime: |
+      craftctl default
+      rm -rf /root/.cache/go-build
+  
+  llvm:
+    plugin: nil
+    build-packages:
+      # Required for `apt-get source`
+      - dpkg-dev
+    override-pull: |
+      mkdir -p /tmp/llvm
+      cd /tmp/llvm
+      apt-get source -y llvm-toolchain-19
+      cp -r llvm-toolchain-19-*/. $CRAFT_PART_SRC
+    override-build: |
+      apt-get build-dep -y llvm-toolchain-19
+
+      mkdir -p llvm/build-native
+      cd llvm/build-native
+
+      cmake .. -G "Ninja" \
+        -DLLVM_TARGETS_TO_BUILD="BPF" \
+        -DLLVM_ENABLE_PROJECTS="clang" \
+        -DBUILD_SHARED_LIBS="OFF" \
+        -DLLVM_BUILD_STATIC="ON" \
+        -DCMAKE_CXX_FLAGS="-s -flto" \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DLLVM_BUILD_RUNTIME="OFF" \
+        -DCMAKE_INSTALL_PREFIX="/usr/local"
+
+      ninja clang llc llvm-objcopy llvm-strip
+
+      strip bin/clang
+      strip bin/llc
+      strip bin/llvm-objcopy
+      strip bin/llvm-strip
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp bin/clang bin/llc bin/llvm-objcopy bin/llvm-strip $CRAFT_PART_INSTALL/usr/local/bin/

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -26,7 +26,7 @@ package-repositories:
   - type: apt
     formats: [deb, deb-src]
     components: [main]
-    suites: [llvm-toolchain-jammy-17, llvm-toolchain-jammy-18]
+    suites: [llvm-toolchain-jammy-17, llvm-toolchain-jammy-19]
     key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
     url: http://apt.llvm.org/jammy/
 
@@ -365,27 +365,30 @@ parts:
     override-pull: |
       mkdir -p /tmp/llvm
       cd /tmp/llvm
-      apt-get source -y llvm-toolchain-18
-      cp -r llvm-toolchain-18-*/. $CRAFT_PART_SRC
+      apt-get source -y llvm-toolchain-19
+      cp -r llvm-toolchain-19-*/. $CRAFT_PART_SRC
     override-build: |
-      apt-get build-dep -y llvm-toolchain-18
+      apt-get build-dep -y llvm-toolchain-19
 
-      mkdir -p llvm/build-native
-      cd llvm/build-native
+      mkdir -p llvm/build
+      cd llvm/build
 
       cmake .. -G "Ninja" \
-        -DLLVM_TARGETS_TO_BUILD="BPF" \
-        -DLLVM_ENABLE_PROJECTS="clang" \
-        -DBUILD_SHARED_LIBS="OFF" \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DLLVM_BUILD_RUNTIME="OFF" \
-        -DCMAKE_INSTALL_PREFIX="/usr/local"
+          -DLLVM_TARGETS_TO_BUILD="BPF" \
+          -DLLVM_ENABLE_PROJECTS="clang" \
+          -DBUILD_SHARED_LIBS="OFF" \
+          -DLLVM_BUILD_STATIC="ON" \
+          -DCMAKE_CXX_FLAGS="-O2" \
+          -DCMAKE_BUILD_TYPE="Release" \
+          -DLLVM_BUILD_RUNTIME="OFF" \
+          -DCMAKE_INSTALL_PREFIX="/usr/local"
 
-      ninja clang llc llvm-objcopy
+      ninja clang llc llvm-objcopy llvm-strip
 
       strip bin/clang
       strip bin/llc
       strip bin/llvm-objcopy
+      strip bin/llvm-strip
 
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
-      cp bin/clang bin/llc bin/llvm-objcopy $CRAFT_PART_INSTALL/usr/local/bin/
+      cp bin/clang bin/llc bin/llvm-objcopy bin/llvm-strip $CRAFT_PART_INSTALL/usr/local/bin/

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -377,8 +377,8 @@ parts:
           -DLLVM_TARGETS_TO_BUILD="BPF" \
           -DLLVM_ENABLE_PROJECTS="clang" \
           -DBUILD_SHARED_LIBS="OFF" \
-          -DLLVM_BUILD_STATIC="ON" \
-          -DCMAKE_CXX_FLAGS="-O2" \
+          -DLLVM_BUILD_STATIC="OFF" \
+          -DCMAKE_CXX_FLAGS="-s -flto" \
           -DCMAKE_BUILD_TYPE="Release" \
           -DLLVM_BUILD_RUNTIME="OFF" \
           -DCMAKE_INSTALL_PREFIX="/usr/local"

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -377,7 +377,7 @@ parts:
           -DLLVM_TARGETS_TO_BUILD="BPF" \
           -DLLVM_ENABLE_PROJECTS="clang" \
           -DBUILD_SHARED_LIBS="OFF" \
-          -DCMAKE_CXX_FLAGS="-s -flto" \
+          -DCMAKE_CXX_FLAGS="-s -O2" \
           -DCMAKE_BUILD_TYPE="Release" \
           -DLLVM_BUILD_RUNTIME="OFF" \
           -DCMAKE_INSTALL_PREFIX="/usr/local"

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -26,7 +26,7 @@ package-repositories:
   - type: apt
     formats: [deb, deb-src]
     components: [main]
-    suites: [llvm-toolchain-jammy-17 llvm-toolchain-jammy-19]
+    suites: [llvm-toolchain-jammy-17, llvm-toolchain-jammy-18]
     key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
     url: http://apt.llvm.org/jammy/
 
@@ -365,10 +365,10 @@ parts:
     override-pull: |
       mkdir -p /tmp/llvm
       cd /tmp/llvm
-      apt-get source -y llvm-toolchain-19
-      cp -r llvm-toolchain-19-*/. $CRAFT_PART_SRC
+      apt-get source -y llvm-toolchain-18
+      cp -r llvm-toolchain-18-*/. $CRAFT_PART_SRC
     override-build: |
-      apt-get build-dep -y llvm-toolchain-19
+      apt-get build-dep -y llvm-toolchain-18
 
       mkdir -p llvm/build-native
       cd llvm/build-native
@@ -377,18 +377,15 @@ parts:
         -DLLVM_TARGETS_TO_BUILD="BPF" \
         -DLLVM_ENABLE_PROJECTS="clang" \
         -DBUILD_SHARED_LIBS="OFF" \
-        -DLLVM_BUILD_STATIC="ON" \
-        -DCMAKE_CXX_FLAGS="-s -flto" \
         -DCMAKE_BUILD_TYPE="Release" \
         -DLLVM_BUILD_RUNTIME="OFF" \
         -DCMAKE_INSTALL_PREFIX="/usr/local"
 
-      ninja clang llc llvm-objcopy llvm-strip
+      ninja clang llc llvm-objcopy
 
       strip bin/clang
       strip bin/llc
       strip bin/llvm-objcopy
-      strip bin/llvm-strip
 
       mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
-      cp bin/clang bin/llc bin/llvm-objcopy bin/llvm-strip $CRAFT_PART_INSTALL/usr/local/bin/
+      cp bin/clang bin/llc bin/llvm-objcopy $CRAFT_PART_INSTALL/usr/local/bin/


### PR DESCRIPTION
Adds Cilium 1.18.4

## Notable changes
1) CNI version bumped to `v1.8.0` from `v1.7.1`
2) Cilium version bumped to `1.18.4`
3) LLVM toolchain bumped to 19 from 17 and built dynamically. The upstream has decided to switch to static building so that the binaries can be run on a `scratch` base. Since we are using Ubuntu anyways, we are building the binaries dynamically.

## Issues
A segmentation fault error happens during the Cilium agent execution when building `llvm` with the upstream `-flto` flag. This is the failing command stripped and tested individually:
```
root@test-noble:/# clang -I/var/run/cilium/state/globals -I/var/run/cilium/state -I/var/lib/cilium/bpf -I/var/lib/cilium/bpf/include -g -O2 --target=bpf -std=gnu99 -nostdinc -ftrap-function=__undefined_trap -Wall -Wextra -Werror -Wshadow -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end -Wimplicit-int-conversion -Wenum-conversion -Wimplicit-fallthrough -mcpu=v3 -c /var/lib/cilium/bpf/bpf_sock.c --debug -v -o -
clang version 19.1.7
Target: bpf
Thread model: posix
InstalledDir: /usr/local/bin
 (in-process)
 "/usr/local/bin/clang" -cc1 -triple bpf -emit-obj -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name bpf_sock.c -mrelocation-model static -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -target-cpu v3 -debug-info-kind=constructor -dwarf-version=5 -debugger-tuning=gdb -fdebug-compilation-dir=/ -v -fcoverage-compilation-dir=/ -nostdsysteminc -nobuiltininc -resource-dir /usr/local/lib/clang/19 -I /var/run/cilium/state/globals -I /var/run/cilium/state -I /var/lib/cilium/bpf -I /var/lib/cilium/bpf/include -O2 -Wall -Wextra -Werror -Wshadow -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end -Wimplicit-int-conversion -Wenum-conversion -Wimplicit-fallthrough -std=gnu99 -ferror-limit 19 -ftrap-function=__undefined_trap -fgnuc-version=4.2.1 -fskip-odr-check-in-gmf -fcolor-diagnostics -vectorize-loops -vectorize-slp -faddrsig -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o - -x c /var/lib/cilium/bpf/bpf_sock.c
clang -cc1 version 19.1.7 based upon LLVM 19.1.7 default target 
#include "..." search starts here:
#include <...> search starts here:
 /var/run/cilium/state/globals
 /var/run/cilium/state
 /var/lib/cilium/bpf
 /var/lib/cilium/bpf/include
End of search list.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.	Program arguments: clang -I/var/run/cilium/state/globals -I/var/run/cilium/state -I/var/lib/cilium/bpf -I/var/lib/cilium/bpf/include -g -O2 --target=bpf -std=gnu99 -nostdinc -ftrap-function=__undefined_trap -Wall -Wextra -Werror -Wshadow -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end -Wimplicit-int-conversion -Wenum-conversion -Wimplicit-fallthrough -mcpu=v3 -c /var/lib/cilium/bpf/bpf_sock.c --debug -v -o -
1.	<eof> parser at end of file
2.	Optimizer
3.	Running pass "ipsccp" on module "/var/lib/cilium/bpf/bpf_sock.c"
Segmentation fault (core dumped)
```
This is not reported for the upstream image which uses Ubuntu 24.04. We use Ubuntu 22.04. This flag instructs the compiler to build LLVM with rigorous optimization to reduce the size of the final object and also may result in a bit faster clang builds. 

## Solution
Using the standard `-O2` optimization instead of the aggressive `-flto` resolves the issue. 