### PR TITLE
feat: add `1.17.12` static

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,7 +17,7 @@ jobs:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
-      cache-action: skip
+      cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64", "amd64"]'
       platform-labels: '{"arm64": ["self-hosted", "linux", "arm64", "jammy", "xlarge"], "amd64": ["self-hosted", "linux", "amd64", "jammy", "xlarge"]}'
       enabled-ubuntu-pro-features: "fips-updates"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@KU-4790-static-workflows
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@KU-4790-static-workflows
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"

--- a/.rockcraft-version.yaml
+++ b/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    revision: 3494
+  - architecture: arm64
+    revision: 3547

--- a/1.17.12/cilium-operator-generic/rockcraft.yaml
+++ b/1.17.12/cilium-operator-generic/rockcraft.yaml
@@ -1,0 +1,158 @@
+name: cilium-operator-generic
+summary: Cilium operator rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/operator-generic image.
+version: "1.17.12"
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  GOPS_CONFIG_DIR: "/"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-operator-generic
+    override: replace
+    startup: enabled
+
+parts:
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      # TODO: Revert back to go 1.23 when this is solved: https://bugs.launchpad.net/go-snap/+bug/21.17.12
+      # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/Dockerfile#L7
+      - go/1.24-fips/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/Dockerfile#L66-L70
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/build-debug-wrapper.sh
+  debug-wrapper:
+    after: [build-deps, builder-img-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.17.12
+    source-subdir: images/builder
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      cd $CRAFT_PART_SRC_WORK
+      go install github.com/go-delve/delve/cmd/dlv@latest
+      go install -ldflags "-s -w" debug-wrapper.go
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoc.sh
+  protoc:
+    plugin: cmake
+    source-type: git
+    source: https://github.com/protocolbuffers/protobuf.git
+    source-tag: v33.3
+    source-submodules:
+      - third_party/googletest
+      - third_party/abseil-cpp
+      - third_party/jsoncpp
+    cmake-generator: Ninja
+    build-packages:
+      - g++
+      - git
+    override-build: |
+      cmake $CRAFT_PART_SRC -G Ninja \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_INSTALL_PREFIX="$CRAFT_PART_INSTALL/usr/local"
+      ninja install
+    stage:
+    - -usr/local/lib
+    - -usr/local/include/absl
+    - -usr/local/include/utf8_range.h
+    - -usr/local/include/utf8_validity.h
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoplugins.sh
+  protoplugins:
+    plugin: go
+    source: ""
+    override-build: |
+      snap refresh go --channel 1.24-fips/stable
+
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.0
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+      go install github.com/mfridman/protoc-gen-go-json@v1.5.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - ca-certificates
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/operator/Dockerfile#L49-L55
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/google/gops.git
+    # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/build-gops.sh#L11-L12
+    source-tag: v0.3.27
+    build-environment:
+      - CGO_ENABLED: "1"
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
+      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+    override-build: |
+      snap refresh go --channel 1.24-fips/stable
+
+      go install -ldflags "-s -w" ./...
+
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/operator/Dockerfile
+  # https://github.com/cilium/cilium/blob/v1.17.12/Makefile#L65-L66
+  cilium-operator:
+    after: [build-deps, builder-img-deps]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.17.12
+    build-environment:
+     - CGO_ENABLED: "1"
+     - GOTOOLCHAIN: local
+     - GOEXPERIMENT: opensslcrypto
+     - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+     - GO_BUILD_LDFLAGS: "-linkmode external"
+    override-build: |
+      snap refresh go --channel 1.24-fips/stable
+
+      # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
+      find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
+
+      export VARIANT="generic"
+      make build-container-operator-$VARIANT
+      export DESTDIR=$CRAFT_PART_INSTALL
+      make install-container-binary-operator-$VARIANT
+      make licenses-all
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/

--- a/1.17.12/cilium-operator-generic/static/.rockcraft-version.yaml
+++ b/1.17.12/cilium-operator-generic/static/.rockcraft-version.yaml
@@ -4,5 +4,4 @@ versions:
   - architecture: arm64
     channel: latest/stable
 
-pro-features: disable
-
+pro-features: disabled

--- a/1.17.12/cilium-operator-generic/static/.rockcraft-version.yaml
+++ b/1.17.12/cilium-operator-generic/static/.rockcraft-version.yaml
@@ -1,0 +1,8 @@
+versions:
+  - architecture: amd64
+    channel: latest/stable
+  - architecture: arm64
+    channel: latest/stable
+
+pro-features: disable
+

--- a/1.17.12/cilium-operator-generic/static/rockcraft.yaml
+++ b/1.17.12/cilium-operator-generic/static/rockcraft.yaml
@@ -1,0 +1,138 @@
+name: cilium-operator-generic
+summary: Cilium operator rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/operator-generic image.
+version: "1.17.12"
+license: Apache-2.0
+
+base: bare
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  GOPS_CONFIG_DIR: "/"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-operator-generic
+    override: replace
+    startup: enabled
+
+parts:
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/Dockerfile#L7
+      - go/1.24/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/Dockerfile#L66-L70
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/build-debug-wrapper.sh
+  debug-wrapper:
+    after: [build-deps, builder-img-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.17.12
+    source-subdir: images/builder
+    build-environment:
+      - CGO_ENABLED: 0
+    override-build: |
+      cd $CRAFT_PART_SRC_WORK
+      go install github.com/go-delve/delve/cmd/dlv@latest
+      go install -ldflags "-s -w" debug-wrapper.go
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoc.sh
+  protoc:
+    plugin: cmake
+    source-type: git
+    source: https://github.com/protocolbuffers/protobuf.git
+    source-tag: v33.3
+    source-submodules:
+      - third_party/googletest
+      - third_party/abseil-cpp
+      - third_party/jsoncpp
+    cmake-generator: Ninja
+    build-packages:
+      - g++
+      - git
+    override-build: |
+      cmake $CRAFT_PART_SRC -G Ninja \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DCMAKE_INSTALL_PREFIX="$CRAFT_PART_INSTALL/usr/local"
+      ninja install
+    stage:
+    - -usr/local/lib
+    - -usr/local/include/absl
+    - -usr/local/include/utf8_range.h
+    - -usr/local/include/utf8_validity.h
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoplugins.sh
+  protoplugins:
+    plugin: go
+    source: ""
+    override-build: |
+      snap refresh go --channel 1.24/stable
+
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.0
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+      go install github.com/mfridman/protoc-gen-go-json@v1.5.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - ca-certificates
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/operator/Dockerfile#L49-L55
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/google/gops.git
+    # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/build-gops.sh#L11-L12
+    source-tag: v0.3.27
+    build-environment:
+      - CGO_ENABLED: "0"
+    override-build: |
+      snap refresh go --channel 1.24/stable
+
+      go install -ldflags "-s -w" ./...
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/operator/Dockerfile
+  # https://github.com/cilium/cilium/blob/v1.17.12/Makefile#L65-L66
+  cilium-operator:
+    after: [build-deps, builder-img-deps]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.17.12
+    override-build: |
+      snap refresh go --channel 1.24/stable
+
+      export VARIANT="generic"
+      make build-container-operator-$VARIANT
+      export DESTDIR=$CRAFT_PART_INSTALL
+      make install-container-binary-operator-$VARIANT
+      make licenses-all
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/

--- a/1.17.12/cilium/envoy-fixes.patch
+++ b/1.17.12/cilium/envoy-fixes.patch
@@ -1,0 +1,25 @@
+From 7f2e2b47b7c13f4c7bf0cf5a61b1e7981579dce5 Mon Sep 17 00:00:00 2001
+From: rapour <reza.abbasalipour@canonical.com>
+Date: Wed, 29 Oct 2025 18:30:45 +0400
+Subject: [PATCH] fix ignore_root_user_error
+
+Signed-off-by: rapour <reza.abbasalipour@canonical.com>
+---
+ WORKSPACE | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index 6439f904..f7003252 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -77,7 +77,7 @@ envoy_dependencies()
+ 
+ load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+ 
+-envoy_dependencies_extra()
++envoy_dependencies_extra(ignore_root_user_error=True)
+ 
+ load("@envoy//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+ 
+-- 
+2.43.0

--- a/1.17.12/cilium/iptables-wrapper-installer.sh
+++ b/1.17.12/cilium/iptables-wrapper-installer.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+# https://github.com/kubernetes-sigs/iptables-wrappers/blob/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eux
+
+# Find iptables binary location
+if [ -n "$OVERRIDE_SBIN" ]; then
+  sbin="$OVERRIDE_SBIN"
+elif [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+  sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+  sbin="/sbin"
+else
+  echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+  exit 1
+fi
+
+if [ -n "$OVERRIDE_PATH" ]; then
+  target="$OVERRIDE_PATH"
+else
+  target="$sbin"
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -n "$OVERRIDE_ALTSTYLE" ]; then
+  altstyle="$OVERRIDE_ALTSTYLE"
+elif [ -x /usr/sbin/alternatives ]; then
+  # Fedora/SUSE style alternatives
+  altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+  # Debian style alternatives
+  altstyle="debian"
+else
+  # No alternatives system
+  altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+  # Ensure dependencies are installed
+  if ! version=$("${sbin}/iptables-nft" --version 2>/dev/null); then
+    echo "ERROR: iptables-nft is not installed" 1>&2
+    exit 1
+  fi
+  if ! "${sbin}/iptables-legacy" --version >/dev/null 2>&1; then
+    echo "ERROR: iptables-legacy is not installed" 1>&2
+    exit 1
+  fi
+
+  case "${version}" in
+  *v1.8.[0123]\ *)
+    echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+    echo "       Upgrade to 1.8.4 or newer." 1>&2
+    exit 1
+    ;;
+  *)
+    # 1.8.4+ are OK
+    ;;
+  esac
+fi
+
+# Start creating the wrapper...
+rm -f "${target}/iptables-wrapper"
+cat >"${target}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+fedora)
+  cat >>"${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+  ;;
+
+debian)
+  cat >>"${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+  ;;
+
+*)
+  cat >>"${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+  ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >>"${target}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${target}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+fedora)
+  alternatives \
+    --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+    --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+  ;;
+
+debian)
+  update-alternatives \
+    --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+    --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+  update-alternatives \
+    --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+    --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+  ;;
+
+*)
+  for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${target}/${cmd}"
+    ln -s "${sbin}/iptables-wrapper" "${target}/${cmd}"
+  done
+  ;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/1.17.12/cilium/rockcraft.yaml
+++ b/1.17.12/cilium/rockcraft.yaml
@@ -1,0 +1,383 @@
+name: cilium
+summary: Cilium agent rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/cilium image.
+version: "1.17.12"
+license: Apache-2.0
+
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+package-repositories:
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy, jammy-updates]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://archive.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy-security]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://security.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb, deb-src]
+    components: [main]
+    suites: [llvm-toolchain-jammy-17]
+    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
+    url: http://apt.llvm.org/jammy/
+
+environment:
+  HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
+  INITSYSTEM: "SYSTEMD"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-dbg
+    override: replace
+    startup: enabled
+
+parts:
+  # https://github.com/cilium/proxy/blob/v1.33/Dockerfile.builder#L44-L46
+  bazelisk:
+    plugin: nil
+    build-packages:
+      - wget
+    overlay-script: |
+      wget https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-$CRAFT_ARCH_BUILD_FOR
+      mv bazelisk-linux-$CRAFT_ARCH_BUILD_FOR /usr/bin/bazelisk
+      chmod +x /usr/bin/bazelisk
+      ln -sf /usr/bin/bazelisk /usr/bin/bazel
+
+  # https://github.com/cilium/proxy/blob/v1.34/Dockerfile#L17-L24
+  cilium-envoy:
+    after: [bazelisk]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/proxy.git
+    source-tag: v1.34
+    source-depth: 1
+    build-packages:
+      - autoconf
+      - automake
+      - cmake
+      - coreutils
+      - curl
+      - git
+      - libtool
+      - make
+      - ninja-build
+      - patch
+      - patchelf
+      - python3
+      - python-is-python3
+      - unzip
+      - virtualenv
+      - wget
+      - zip
+      - libc6-dev
+      - gcc
+      - binutils
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    override-build: |
+      export PKG_BUILD=1
+      export DESTDIR=$CRAFT_PART_INSTALL
+      export EMAIL=root@localhost
+      git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
+
+      make -C proxylib all
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so /usr/lib/
+      git rev-parse HEAD >SOURCE_VERSION
+      make bazel-bin/cilium-envoy
+      make install
+      rm -rf /root/.cache/bazel
+
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+      - ccache
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/Dockerfile#L7
+      - go/1.24-fips/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+      # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoc.sh
+      - protobuf-compiler
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoplugins.sh
+  protoplugins:
+    plugin: nil
+    overlay-script: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.0
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+      go install github.com/mfridman/protoc-gen-go-json@v1.5.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - bash-completion
+      - iproute2
+      - ipset
+      - kmod
+      - ca-certificates
+
+  iptables:
+    plugin: nil
+    stage-packages:
+      - iptables
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L46-L47
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/iptables-wrapper-installer.sh
+  iptables-wrapper:
+    after: [iptables]
+    plugin: nil
+    source-type: file
+    # NOTE: we maintain out own version of ./iptables-wrapper-installer.sh.
+    source: ./iptables-wrapper-installer.sh
+    build-environment:
+    - OVERRIDE_PATH: "$CRAFT_PRIME/usr/sbin"
+    - OVERRIDE_SBIN: "/usr/sbin"
+    - OVERRIDE_ALTSTYLE: "none"
+    override-prime: |
+      craftctl default
+      bash $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L9
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L50
+  # https://github.com/cilium/image-tools/blob/master/images/bpftool/Dockerfile#L12-L13
+  # TODO: see https://github.com/cilium/image-tools/pull/366
+  bpftool:
+    plugin: make
+    source-type: git
+    source: https://github.com/libbpf/bpftool.git
+    source-tag: v7.4.0
+    source-depth: 1
+    source-subdir: src
+    source-submodules:
+      - "libbpf"
+    build-packages:
+      - xz-utils
+      - libzstd-dev
+      - zlib1g-dev
+      - libelf-dev
+      - libiberty-dev
+      - llvm-17
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    build-environment:
+      - EXTRA_CFLAGS: --static
+      - LLVM_CONFIG: "/usr/bin/llvm-config-17"
+      - LLVM_STRIP: "/usr/bin/llvm-strip-17"
+    override-build: |
+      # libelf requires zstd on Ubuntu 24.04, this hasn't been addressed
+      # in bpftool yet.
+      sed -i 's/-lelf/-lelf -lzstd/g' src/Makefile
+
+      make -C src -j "$(nproc)"
+      strip src/bpftool
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin/
+      cp ./src/bpftool $CRAFT_PART_INSTALL/usr/local/sbin/
+      chmod 755 $CRAFT_PART_INSTALL/usr/local/sbin/bpftool
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L20-L23
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/build-gops.sh#L11-L12
+    source: https://github.com/google/gops.git
+    source-tag: v0.3.27
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: "1"
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
+      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      go install -ldflags "-s -w" ./...
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L24-L26
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/download-cni.sh#L13
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/cni-version.sh#L2
+  cni-plugins:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/containernetworking/plugins.git
+    source-tag: v1.9.0
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: "1"
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
+      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      ./build_linux.sh
+      strip $CRAFT_PART_BUILD/bin/loopback
+      cp -r $CRAFT_PART_BUILD/bin $CRAFT_PART_INSTALL
+    stage:
+      - -bin
+    organize:
+      bin/loopback: cni/loopback
+
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
+
+  zig:
+    plugin: nil
+    build-packages:
+      - tar
+      - curl
+    override-build: |
+      ARCH=x86_64
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        ARCH=aarch64
+      fi
+
+      curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
+      mkdir -p /zig
+      tar --strip-components 1 -xf zig.tar.xz -C /zig
+
+      ln -sf /zig/zig /usr/bin/zig
+
+  cilium:
+    after: [build-deps, builder-img-deps, zig]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.17.12
+    build-packages:
+      - clang-17
+      - llvm-17
+    build-environment:
+     - DISABLE_ENVOY_INSTALLATION: "1"
+     - CGO_ENABLED: "1"
+     - GOTOOLCHAIN: local
+     - GOEXPERIMENT: opensslcrypto
+     - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
+     - GO_BUILD_LDFLAGS: "-linkmode external"
+     - PKG_BUILD: "1"
+     - NOSTRIP: "0"
+     - NOOPT: "0"
+    override-build: |
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24-fips/stable
+
+      # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
+      find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
+
+      # Note(Reza): The target must match the glibc version corresponding to the oldest supported host.
+      CXX="zig c++ -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" CC="zig cc -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" make build-container
+
+      make install-container-binary
+      make install-bash-completion
+      make licenses-all
+
+      # Build Hubble from the subdirectory within Cilium repo
+      cd hubble
+      make
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      cp hubble $CRAFT_PART_INSTALL/usr/bin/hubble
+      cd ..
+
+      # Generate Hubble bash completion
+      mkdir -p $CRAFT_PART_INSTALL/etc/bash_completion.d
+      $CRAFT_PART_INSTALL/usr/bin/hubble completion bash > $CRAFT_PART_INSTALL/etc/bash_completion.d/hubble
+
+
+      echo 'install_cni "/usr/bin/cilium-dbg"' >> $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/images/cilium/init-container.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/plugins/cilium-cni/cni-uninstall.sh $CRAFT_PART_INSTALL/
+
+      find $CRAFT_PART_INSTALL -type f -executable -exec sh -c 'objcopy --strip-all ${0}' {} \;
+    override-prime: |
+      craftctl default
+      rm -rf /root/.cache/go-build
+
+  llvm:
+    plugin: nil
+    build-packages:
+      # Required for `apt-get source`
+      - dpkg-dev
+    override-pull: |
+      mkdir -p /tmp/llvm
+      cd /tmp/llvm
+      apt-get source -y llvm-toolchain-17
+      cp -r llvm-toolchain-17-*/. $CRAFT_PART_SRC
+    override-build: |
+      apt-get build-dep -y llvm-toolchain-17
+
+      mkdir -p llvm/build-native
+      cd llvm/build-native
+
+      cmake .. -G "Ninja" \
+        -DLLVM_TARGETS_TO_BUILD="BPF" \
+        -DLLVM_ENABLE_PROJECTS="clang" \
+        -DBUILD_SHARED_LIBS="OFF" \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DLLVM_BUILD_RUNTIME="OFF" \
+        -DCMAKE_INSTALL_PREFIX="/usr/local"
+
+      ninja clang llc
+
+      strip bin/clang
+      strip bin/llc
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp bin/clang bin/llc $CRAFT_PART_INSTALL/usr/local/bin/

--- a/1.17.12/cilium/static/.rockcraft-version.yaml
+++ b/1.17.12/cilium/static/.rockcraft-version.yaml
@@ -4,4 +4,4 @@ versions:
   - architecture: arm64
     channel: latest/stable
 
-pro-features: disable
+pro-features: disabled

--- a/1.17.12/cilium/static/.rockcraft-version.yaml
+++ b/1.17.12/cilium/static/.rockcraft-version.yaml
@@ -1,0 +1,7 @@
+versions:
+  - architecture: amd64
+    channel: latest/stable
+  - architecture: arm64
+    channel: latest/stable
+
+pro-features: disable

--- a/1.17.12/cilium/static/envoy-fixes.patch
+++ b/1.17.12/cilium/static/envoy-fixes.patch
@@ -1,0 +1,25 @@
+From 7f2e2b47b7c13f4c7bf0cf5a61b1e7981579dce5 Mon Sep 17 00:00:00 2001
+From: rapour <reza.abbasalipour@canonical.com>
+Date: Wed, 29 Oct 2025 18:30:45 +0400
+Subject: [PATCH] fix ignore_root_user_error
+
+Signed-off-by: rapour <reza.abbasalipour@canonical.com>
+---
+ WORKSPACE | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index 6439f904..f7003252 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -77,7 +77,7 @@ envoy_dependencies()
+ 
+ load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+ 
+-envoy_dependencies_extra()
++envoy_dependencies_extra(ignore_root_user_error=True)
+ 
+ load("@envoy//bazel:python_dependencies.bzl", "envoy_python_dependencies")
+ 
+-- 
+2.43.0

--- a/1.17.12/cilium/static/iptables-wrapper-installer.sh
+++ b/1.17.12/cilium/static/iptables-wrapper-installer.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+# https://github.com/kubernetes-sigs/iptables-wrappers/blob/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eux
+
+# Find iptables binary location
+if [ -n "$OVERRIDE_SBIN" ]; then
+  sbin="$OVERRIDE_SBIN"
+elif [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+  sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+  sbin="/sbin"
+else
+  echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+  exit 1
+fi
+
+if [ -n "$OVERRIDE_PATH" ]; then
+  target="$OVERRIDE_PATH"
+else
+  target="$sbin"
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -n "$OVERRIDE_ALTSTYLE" ]; then
+  altstyle="$OVERRIDE_ALTSTYLE"
+elif [ -x /usr/sbin/alternatives ]; then
+  # Fedora/SUSE style alternatives
+  altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+  # Debian style alternatives
+  altstyle="debian"
+else
+  # No alternatives system
+  altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+  # Ensure dependencies are installed
+  if ! version=$("${sbin}/iptables-nft" --version 2>/dev/null); then
+    echo "ERROR: iptables-nft is not installed" 1>&2
+    exit 1
+  fi
+  if ! "${sbin}/iptables-legacy" --version >/dev/null 2>&1; then
+    echo "ERROR: iptables-legacy is not installed" 1>&2
+    exit 1
+  fi
+
+  case "${version}" in
+  *v1.8.[0123]\ *)
+    echo "ERROR: iptables 1.8.0 - 1.8.3 have compatibility bugs." 1>&2
+    echo "       Upgrade to 1.8.4 or newer." 1>&2
+    exit 1
+    ;;
+  *)
+    # 1.8.4+ are OK
+    ;;
+  esac
+fi
+
+# Start creating the wrapper...
+rm -f "${target}/iptables-wrapper"
+cat >"${target}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# In kubernetes 1.17 and later, kubelet will have created at least
+# one chain in the "mangle" table (either "KUBE-IPTABLES-HINT" or
+# "KUBE-KUBELET-CANARY"), so check that first, against
+# iptables-nft, because we can check that more efficiently and
+# it's more common these days.
+nft_kubelet_rules=\$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+if [ "\${nft_kubelet_rules}" -ne 0 ]; then
+    mode=nft
+else
+    # Check for kubernetes 1.17-or-later with iptables-legacy. We
+    # can't pass "-t mangle" to iptables-legacy-save because it would
+    # cause the kernel to create that table if it didn't already
+    # exist, which we don't want. So we have to grab all the rules
+    legacy_kubelet_rules=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)' | wc -l)
+    if [ "\${legacy_kubelet_rules}" -ne 0 ]; then
+        mode=legacy
+    else
+        # With older kubernetes releases there may not be any _specific_
+        # rules we can look for, but we assume that some non-containerized process
+        # (possibly kubelet) will have created _some_ iptables rules.
+        num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+        num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+        if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
+            mode=legacy
+        else
+            mode=nft
+        fi
+    fi
+fi
+
+EOF
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+fedora)
+  cat >>"${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+  ;;
+
+debian)
+  cat >>"${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+  ;;
+
+*)
+  cat >>"${target}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+  ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >>"${target}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${target}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+fedora)
+  alternatives \
+    --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+    --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+  ;;
+
+debian)
+  update-alternatives \
+    --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+    --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+  update-alternatives \
+    --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+    --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+  ;;
+
+*)
+  for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${target}/${cmd}"
+    ln -s "${sbin}/iptables-wrapper" "${target}/${cmd}"
+  done
+  ;;
+esac
+
+# Cleanup
+rm -f "$0"

--- a/1.17.12/cilium/static/rockcraft.yaml
+++ b/1.17.12/cilium/static/rockcraft.yaml
@@ -1,0 +1,342 @@
+name: cilium
+summary: Cilium agent rock for the Cilium CNI.
+description: This rock is a drop in replacement for the cilium/cilium image.
+version: "1.17.12"
+license: Apache-2.0
+
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+package-repositories:
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy, jammy-updates]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://archive.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy-security]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://security.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb, deb-src]
+    components: [main]
+    suites: [llvm-toolchain-jammy-17]
+    key-id: 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
+    url: http://apt.llvm.org/jammy/
+
+environment:
+  HUBBLE_SERVER: "unix:///var/run/cilium/hubble.sock"
+  INITSYSTEM: "SYSTEMD"
+
+services:
+  cilium:
+    command: /usr/bin/cilium-dbg
+    override: replace
+    startup: enabled
+
+parts:
+  # https://github.com/cilium/proxy/blob/v1.33/Dockerfile.builder#L44-L46
+  bazelisk:
+    plugin: nil
+    build-packages:
+      - wget
+    overlay-script: |
+      wget https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$CRAFT_ARCH_BUILD_FOR
+      mv bazelisk-linux-$CRAFT_ARCH_BUILD_FOR /usr/bin/bazelisk
+      chmod +x /usr/bin/bazelisk
+      ln -sf /usr/bin/bazelisk /usr/bin/bazel
+
+  # https://github.com/cilium/proxy/blob/v1.31/Dockerfile#L17-L24
+  cilium-envoy:
+    after: [bazelisk]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/proxy.git
+    source-tag: v1.31
+    source-depth: 1
+    build-packages:
+      - autoconf
+      - automake
+      - cmake
+      - coreutils
+      - curl
+      - git
+      - libtool
+      - make
+      - ninja-build
+      - patch
+      - patchelf
+      - python3
+      - python-is-python3
+      - unzip
+      - virtualenv
+      - wget
+      - zip
+      - libc6-dev
+      - gcc
+      - binutils
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    override-build: |
+      export PKG_BUILD=1
+      export DESTDIR=$CRAFT_PART_INSTALL
+      export EMAIL=root@localhost
+      git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
+
+      make -C proxylib all
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/
+      cp proxylib/libcilium.so /usr/lib/
+      git rev-parse HEAD >SOURCE_VERSION
+      make bazel-bin/cilium-envoy
+      make install
+      rm -rf /root/.cache/bazel
+
+  builder-img-deps:
+    plugin: nil
+    build-packages:
+      - unzip
+      - binutils
+      - coreutils
+      - curl
+      - gcc
+      - git
+      - libc6-dev
+      - make
+
+  build-deps:
+    plugin: nil
+    build-snaps:
+      # TODO: Revert back to go 1.23 when this is solved: https://bugs.launchpad.net/go-snap/+bug/21.17.12
+      # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/Dockerfile#L7
+      - go/1.24/stable
+    build-packages:
+      - autoconf
+      - automake
+      - autopoint
+      - autotools-dev
+      - build-essential
+      - pkg-config
+      # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoc.sh
+      - protobuf-compiler
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/builder/install-protoplugins.sh
+  protoplugins:
+    plugin: nil
+    overlay-script: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24/stable
+
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.0
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+      go install github.com/mfridman/protoc-gen-go-json@v1.5.0
+      go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+  runtime-img-deps:
+    plugin: nil
+    stage-packages:
+      - jq
+      - bash-completion
+      - iproute2
+      - ipset
+      - kmod
+      - ca-certificates
+      - libz3-dev
+
+  iptables:
+    plugin: nil
+    stage-packages:
+      - iptables
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L46-L47
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/iptables-wrapper-installer.sh
+  iptables-wrapper:
+    after: [iptables]
+    plugin: nil
+    source-type: file
+    # NOTE: we maintain out own version of ./iptables-wrapper-installer.sh.
+    source: ./iptables-wrapper-installer.sh
+    build-environment:
+    - OVERRIDE_PATH: "$CRAFT_PRIME/usr/sbin"
+    - OVERRIDE_SBIN: "/usr/sbin"
+    - OVERRIDE_ALTSTYLE: "none"
+    override-prime: |
+      craftctl default
+      bash $CRAFT_PART_BUILD/iptables-wrapper-installer.sh --no-sanity-check
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L9
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L50
+  # https://github.com/cilium/image-tools/blob/master/images/bpftool/Dockerfile#L12-L13
+  # https://github.com/cilium/image-tools/blob/master/images/bpftool/checkout-linux.sh#L11-L12
+  bpftool:
+    plugin: make
+    source-type: git
+    source: https://github.com/libbpf/bpftool.git
+    source-tag: v7.4.0
+    source-depth: 1
+    source-subdir: src
+    source-submodules:
+      - "libbpf"
+    build-packages:
+      - xz-utils
+      - libzstd-dev
+      - zlib1g-dev
+      - libelf-dev
+      - libiberty-dev
+      - llvm-17
+      - clang-17
+      - clang-tools-17
+      - lldb-17
+      - lld-17
+      - clang-format-17
+      - libc++-17-dev
+      - libc++abi-17-dev
+    build-environment:
+      - EXTRA_CFLAGS: --static
+      - LLVM_CONFIG: "/usr/bin/llvm-config-17"
+      - LLVM_STRIP: "/usr/bin/llvm-strip-17"
+    override-build: |
+      # libelf requires zstd on Ubuntu 24.04, this hasn't been addressed
+      # in bpftool yet.
+      sed -i 's/-lelf/-lelf -lzstd/g' src/Makefile
+
+      make -C src -j "$(nproc)"
+      strip src/bpftool
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/sbin/
+      cp ./src/bpftool $CRAFT_PART_INSTALL/usr/local/sbin/
+      chmod 755 $CRAFT_PART_INSTALL/usr/local/sbin/bpftool
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L20-L23
+  gops:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/build-gops.sh#L11-L12
+    source: https://github.com/google/gops.git
+    source-tag: v0.3.27
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: "0"
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24/stable
+
+      go install -ldflags "-s -w" ./...
+
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/Dockerfile#L24-L26
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/download-cni.sh#L13
+  # https://github.com/cilium/cilium/blob/v1.17.12/images/runtime/cni-version.sh#L2
+  cni-plugins:
+    after: [build-deps]
+    plugin: go
+    source-type: git
+    source: https://github.com/containernetworking/plugins.git
+    source-tag: v1.9.0
+    source-depth: 1
+    override-build: |
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24/stable
+
+      ./build_linux.sh
+      strip $CRAFT_PART_BUILD/bin/loopback
+      cp -r $CRAFT_PART_BUILD/bin $CRAFT_PART_INSTALL
+    stage:
+      - -bin
+    organize:
+      bin/loopback: cni/loopback
+
+  cilium:
+    after: [build-deps, builder-img-deps]
+    plugin: make
+    source-type: git
+    source: https://github.com/cilium/cilium.git
+    source-tag: v1.17.12
+    build-packages:
+      - clang-17
+      - llvm-17
+    build-environment:
+     - DISABLE_ENVOY_INSTALLATION: 1
+     - PKG_BUILD: 1
+     - NOSTRIP: 0
+     - NOOPT: 0
+    override-build: |
+      make build-container
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      # NOTE: (mateoflorido) Something is changing the requested version
+      # in the build-snaps section.
+      snap refresh go --channel 1.24/stable
+
+      make install-container-binary
+      make install-bash-completion
+      make licenses-all
+
+      # Build Hubble from the subdirectory within Cilium repo
+      cd hubble
+      make
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      cp hubble $CRAFT_PART_INSTALL/usr/bin/hubble
+      cd ..
+
+      # Generate Hubble bash completion
+      mkdir -p $CRAFT_PART_INSTALL/etc/bash_completion.d
+      $CRAFT_PART_INSTALL/usr/bin/hubble completion bash > $CRAFT_PART_INSTALL/etc/bash_completion.d/hubble
+
+      echo 'install_cni "/usr/bin/cilium-dbg"' >> $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh
+
+      cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/images/cilium/init-container.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh $CRAFT_PART_INSTALL/
+      cp $CRAFT_PART_SRC/plugins/cilium-cni/cni-uninstall.sh $CRAFT_PART_INSTALL/
+
+      find $CRAFT_PART_INSTALL -type f -executable -exec sh -c 'objcopy --strip-all ${0}' {} \;
+    override-prime: |
+      craftctl default
+      rm -rf /root/.cache/go-build
+
+  llvm:
+    plugin: nil
+    build-packages:
+      # Required for `apt-get source`
+      - dpkg-dev
+    override-pull: |
+      mkdir -p /tmp/llvm
+      cd /tmp/llvm
+      apt-get source -y llvm-toolchain-17
+      cp -r llvm-toolchain-17-*/. $CRAFT_PART_SRC
+    override-build: |
+      apt-get build-dep -y llvm-toolchain-17
+
+      mkdir -p llvm/build-native
+      cd llvm/build-native
+
+      cmake .. -G "Ninja" \
+        -DLLVM_TARGETS_TO_BUILD="BPF" \
+        -DLLVM_ENABLE_PROJECTS="clang" \
+        -DBUILD_SHARED_LIBS="OFF" \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DLLVM_BUILD_RUNTIME="OFF" \
+        -DCMAKE_INSTALL_PREFIX="/usr/local"
+
+      ninja clang llc
+
+      strip bin/clang
+      strip bin/llc
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/bin
+      cp bin/clang bin/llc $CRAFT_PART_INSTALL/usr/local/bin/

--- a/tests/sanity/test_cilium_operator_rock.py
+++ b/tests/sanity/test_cilium_operator_rock.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Canonical, Ltd.
+# Copyright 2026 Canonical, Ltd.
 #
 
 import shlex
@@ -16,7 +16,9 @@ IMAGE_ENTRYPOINT = "cilium-operator-generic --version"
 
 @cache
 def get_rockcraft_yaml(image_version):
-    rockcraft_path = config.REPO_PATH / image_version / "cilium-operator-generic" / "rockcraft.yaml"
+    rockcraft_path = (
+        config.REPO_PATH / image_version / "cilium-operator-generic" / "rockcraft.yaml"
+    )
     return rockcraft_path.read_text().lower()
 
 
@@ -31,7 +33,9 @@ def test_executable(image_version):
     "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
 )
 def test_pebble_executable(image_version):
-    rock.check_pebble(IMAGE_NAME, image_version, config.PEBBLE_VERSION, config.IMAGE_ARCH)
+    rock.check_pebble(
+        IMAGE_NAME, image_version, config.PEBBLE_VERSION, config.IMAGE_ARCH
+    )
 
 
 @pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")

--- a/tests/sanity/test_cilium_operator_rock.py
+++ b/tests/sanity/test_cilium_operator_rock.py
@@ -3,10 +3,9 @@
 #
 
 import shlex
-from functools import cache
 
 import pytest
-from k8s_test_harness.util import docker_util, env_util, fips_util
+from k8s_test_harness.util import docker_util, fips_util
 from test_util import config, rock
 
 IMAGE_NAME = "cilium-operator-generic"
@@ -14,49 +13,45 @@ IMAGE_BASE = f"ghcr.io/canonical/{IMAGE_NAME}"
 IMAGE_ENTRYPOINT = "cilium-operator-generic --version"
 
 
-@cache
-def get_rockcraft_yaml(image_version):
-    rockcraft_path = (
-        config.REPO_PATH / image_version / "cilium-operator-generic" / "rockcraft.yaml"
-    )
-    return rockcraft_path.read_text().lower()
+def get_cilium_operator_params():
+    return rock.get_rock_test_param(IMAGE_NAME, config.IMAGE_ARCH)
 
 
 @pytest.mark.parametrize(
-    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
+    "rock_param", get_cilium_operator_params(), ids=rock.rock_param_id
 )
-def test_executable(image_version):
-    rock.run_image(IMAGE_NAME, image_version, IMAGE_ENTRYPOINT, config.IMAGE_ARCH)
+def test_executable(rock_param: rock.RockTestParam):
+    rock.run_image_direct(rock_param.image, rock_param.version, IMAGE_ENTRYPOINT)
 
 
 @pytest.mark.parametrize(
-    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
+    "rock_param", get_cilium_operator_params(), ids=rock.rock_param_id
 )
-def test_pebble_executable(image_version):
-    rock.check_pebble(
-        IMAGE_NAME, image_version, config.PEBBLE_VERSION, config.IMAGE_ARCH
-    )
+def test_pebble_executable(rock_param: rock.RockTestParam):
+    if rock_param.variant == "static":
+        # Static variants use different rockcraft channels with different pebble versions
+        rock.check_pebble_direct(rock_param.image)
+    else:
+        rock.check_pebble_direct(rock_param.image, config.PEBBLE_VERSION)
 
 
 @pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")
 @pytest.mark.parametrize(
-    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
+    "rock_param", get_cilium_operator_params(), ids=rock.rock_param_id
 )
-def test_fips(image_version, GOFIPS):
-    rockcraft_yaml = get_rockcraft_yaml(image_version)
+def test_fips(rock_param: rock.RockTestParam, GOFIPS):
+    rockcraft_yaml_path = config.REPO_PATH / rock_param.path / "rockcraft.yaml"
+    rockcraft_yaml = rockcraft_yaml_path.read_text()
 
     # TODO: Remove this once this is solved: https://bugs.launchpad.net/go-snap/+bug/2131731
     if GOFIPS == 1 and not fips_util.is_fips_rock(rockcraft_yaml):
         pytest.skip("This version of the ROCK is not built for FIPS")
 
-    image = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, config.IMAGE_ARCH
-    ).image
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]
     process = docker_util.run_in_docker(
-        image, entrypoint, check_exit_code=False, docker_args=docker_env
+        rock_param.image, entrypoint, check_exit_code=False, docker_args=docker_env
     )
 
     expected_returncode, expected_error = fips_util.fips_expectations(
@@ -65,7 +60,7 @@ def test_fips(image_version, GOFIPS):
 
     assert (
         process.returncode == expected_returncode
-    ), f"Return code mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    ), f"Return code mismatch for {entrypoint} in image {rock_param.image}, stderr: {process.stderr}"
     assert (
         expected_error in process.stderr
-    ), f"Error message mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    ), f"Error message mismatch for {entrypoint} in image {rock_param.image}, stderr: {process.stderr}"

--- a/tests/sanity/test_cilium_rock.py
+++ b/tests/sanity/test_cilium_rock.py
@@ -18,15 +18,17 @@ def get_cilium_params():
 
 
 @pytest.mark.parametrize("rock_param", get_cilium_params(), ids=rock.rock_param_id)
-def test_executable(image_version):
-    rock.run_image(IMAGE_NAME, image_version, IMAGE_ENTRYPOINT, config.IMAGE_ARCH)
+def test_executable(rock_param: rock.RockTestParam):
+    rock.run_image_direct(rock_param.image, rock_param.version, IMAGE_ENTRYPOINT)
 
 
 @pytest.mark.parametrize("rock_param", get_cilium_params(), ids=rock.rock_param_id)
-def test_pebble_executable(image_version):
-    rock.check_pebble(
-        IMAGE_NAME, image_version, config.PEBBLE_VERSION, config.IMAGE_ARCH
-    )
+def test_pebble_executable(rock_param: rock.RockTestParam):
+    if rock_param.variant == "static":
+        # Static variants use different rockcraft channels with different pebble versions
+        rock.check_pebble_direct(rock_param.image)
+    else:
+        rock.check_pebble_direct(rock_param.image, config.PEBBLE_VERSION)
 
 
 @pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")

--- a/tests/sanity/test_cilium_rock.py
+++ b/tests/sanity/test_cilium_rock.py
@@ -1,12 +1,11 @@
 #
-# Copyright 2025 Canonical, Ltd.
+# Copyright 2026 Canonical, Ltd.
 #
 
 import shlex
-from functools import cache
 
 import pytest
-from k8s_test_harness.util import docker_util, env_util, fips_util
+from k8s_test_harness.util import docker_util, fips_util
 from test_util import config, rock
 
 IMAGE_NAME = "cilium"
@@ -14,45 +13,37 @@ IMAGE_BASE = f"ghcr.io/canonical/{IMAGE_NAME}"
 IMAGE_ENTRYPOINT = "cilium-agent --version"
 
 
-@cache
-def get_rockcraft_yaml(image_version):
-    rockcraft_path = config.REPO_PATH / image_version / "cilium" / "rockcraft.yaml"
-    return rockcraft_path.read_text().lower()
+def get_cilium_params():
+    return rock.get_rock_test_param(IMAGE_NAME, config.IMAGE_ARCH)
 
 
-@pytest.mark.parametrize(
-    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
-)
+@pytest.mark.parametrize("rock_param", get_cilium_params(), ids=rock.rock_param_id)
 def test_executable(image_version):
     rock.run_image(IMAGE_NAME, image_version, IMAGE_ENTRYPOINT, config.IMAGE_ARCH)
 
 
-@pytest.mark.parametrize(
-    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
-)
+@pytest.mark.parametrize("rock_param", get_cilium_params(), ids=rock.rock_param_id)
 def test_pebble_executable(image_version):
-    rock.check_pebble(IMAGE_NAME, image_version, config.PEBBLE_VERSION, config.IMAGE_ARCH)
+    rock.check_pebble(
+        IMAGE_NAME, image_version, config.PEBBLE_VERSION, config.IMAGE_ARCH
+    )
 
 
 @pytest.mark.parametrize("GOFIPS", [0, 1], ids=lambda v: f"GOFIPS={v}")
-@pytest.mark.parametrize(
-    "image_version", env_util.image_versions_in_repo(IMAGE_NAME, config.REPO_PATH)
-)
-def test_fips(image_version, GOFIPS):
-    rockcraft_yaml = get_rockcraft_yaml(image_version)
+@pytest.mark.parametrize("rock_param", get_cilium_params(), ids=rock.rock_param_id)
+def test_fips(rock_param: rock.RockTestParam, GOFIPS):
+    rockcraft_yaml_path = config.REPO_PATH / rock_param.path / "rockcraft.yaml"
+    rockcraft_yaml = rockcraft_yaml_path.read_text()
 
     # TODO: Remove this once this is solved: https://bugs.launchpad.net/go-snap/+bug/2131731
     if GOFIPS == 1 and not fips_util.is_fips_rock(rockcraft_yaml):
         pytest.skip("This version of the ROCK is not built for FIPS")
 
-    image = env_util.get_build_meta_info_for_rock_version(
-        IMAGE_NAME, image_version, config.IMAGE_ARCH
-    ).image
     entrypoint = shlex.split(IMAGE_ENTRYPOINT)
 
     docker_env = ["-e", f"GOFIPS={GOFIPS}"]
     process = docker_util.run_in_docker(
-        image, entrypoint, check_exit_code=False, docker_args=docker_env
+        rock_param.image, entrypoint, check_exit_code=False, docker_args=docker_env
     )
 
     expected_returncode, expected_error = fips_util.fips_expectations(
@@ -61,7 +52,7 @@ def test_fips(image_version, GOFIPS):
 
     assert (
         process.returncode == expected_returncode
-    ), f"Return code mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    ), f"Return code mismatch for {entrypoint} in image {rock_param.image}, stderr: {process.stderr}"
     assert (
         expected_error in process.stderr
-    ), f"Error message mismatch for {entrypoint} in image {image}, stderr: {process.stderr}"
+    ), f"Error message mismatch for {entrypoint} in image {rock_param.image}, stderr: {process.stderr}"

--- a/tests/sanity/test_util/config.py
+++ b/tests/sanity/test_util/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Canonical, Ltd.
+# Copyright 2026 Canonical, Ltd.
 #
 
 import os

--- a/tests/sanity/test_util/rock.py
+++ b/tests/sanity/test_util/rock.py
@@ -77,3 +77,18 @@ def check_pebble(image_name, image_version, pebble_version, arch):
     docker_util.run_entrypoint_and_assert(
         image, "/bin/pebble version", expect_stdout_contains=pebble_version
     )
+
+
+def run_image_direct(image: str, image_version: str, image_entrypoint: str):
+    """Run entrypoint on image directly without version lookup."""
+    docker_util.run_entrypoint_and_assert(
+        image, image_entrypoint, expect_stdout_contains=image_version
+    )
+
+
+def check_pebble_direct(image: str, pebble_version: str = None):
+    """Check pebble on image. If version provided, validate it; otherwise just check pebble runs."""
+    expected = pebble_version if pebble_version else "client"
+    docker_util.run_entrypoint_and_assert(
+        image, "/bin/pebble version", expect_stdout_contains=expected
+    )

--- a/tests/sanity/test_util/rock.py
+++ b/tests/sanity/test_util/rock.py
@@ -1,8 +1,64 @@
 #
-# Copyright 2025 Canonical, Ltd.
+# Copyright 2026 Canonical, Ltd.
 #
 
+from dataclasses import dataclass
+from typing import List
+
 from k8s_test_harness.util import docker_util, env_util
+
+
+@dataclass
+class RockTestParam:
+    name: str
+    version: str
+    path: str
+    arch: str
+    image: str
+
+    @property
+    def variant(self) -> str:
+        parts = self.path.rstrip("/").split("/")
+        if parts[-1] == self.name:
+            return ""
+        return parts[-1]
+
+    @property
+    def display_id(self) -> str:
+        if self.variant:
+            return f"{self.version}-{self.variant}"
+        return self.version
+
+
+def get_rock_test_param(
+    rock_name: str,
+    arch: str,
+) -> List[RockTestParam]:
+    all_metas = env_util.get_rocks_meta_info_from_env()
+
+    params = []
+    for meta in all_metas:
+        if meta.name != rock_name:
+            continue
+        if meta.arch != arch:
+            continue
+
+        param = RockTestParam(
+            name=meta.name,
+            version=meta.version,
+            path=meta.rock_dir,
+            arch=meta.arch,
+            image=meta.image,
+        )
+        params.append(param)
+
+    params.sort(key=lambda p: (p.version, p.variant))
+
+    return params
+
+
+def rock_param_id(param: RockTestParam) -> str:
+    return param.display_id
 
 
 def run_image(image_name, image_version, image_entrypoint, arch):


### PR DESCRIPTION
> [!WARNING]  
> This PR depends on https://github.com/canonical/k8s-workflows/pull/55. DO NOT MERGE until the workflow is back to tracking main

## Overview
Add support for both FIPS and static builds for Cilium images starting `1.17.12`, targeting `release-{1.32,1.33}`