### PR TITLE
revert: revert zig workaround and use wrapper to link against core22

### DIFF
--- a/1.17.1/cilium/rockcraft.yaml
+++ b/1.17.1/cilium/rockcraft.yaml
@@ -4,6 +4,9 @@ description: This rock is a drop in replacement for the cilium/cilium image.
 version: "1.17.1"
 license: Apache-2.0
 
+# Note(Reza): We are hardcoding the dynamic libraries path inside the cilium
+# part binaries. Change them and also the LD_LIBRARY_PATH in the wrapper codebase
+# accodingly when you change the base snap.
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 platforms:
@@ -293,25 +296,15 @@ parts:
       - openssl-fips-module-3 # a Pro only FIPS package for openssl
       - openssl # now automatically selected from fips-preview
 
-  zig:
-    plugin: nil
-    build-packages:
-      - tar
-      - curl
-    override-build: |
-      ARCH=x86_64
-      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        ARCH=aarch64
-      fi
-
-      curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
-      mkdir -p /zig
-      tar --strip-components 1 -xf zig.tar.xz -C /zig
-
-      ln -sf /zig/zig /usr/bin/zig  
+  wrapper:
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+    - wrapper
 
   cilium:
-    after: [build-deps, builder-img-deps, zig]
+    after: [build-deps, builder-img-deps, wrapper]
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
@@ -325,22 +318,41 @@ parts:
      - GOTOOLCHAIN: local
      - GOEXPERIMENT: opensslcrypto
      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
-     - GO_BUILD_LDFLAGS: "-linkmode external"
      - PKG_BUILD: 1
      - NOSTRIP: 0
      - NOOPT: 0
     override-build: |
-      export DESTDIR=$CRAFT_PART_INSTALL
-
       # NOTE: (mateoflorido) Something is changing the requested version
       # in the build-snaps section.
       snap refresh go --channel 1.24-fips/stable
 
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      LINKER=ld-linux-x86-64.so.2
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+      fi
+
+      export LIBRARY_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      export DYNAMIC_LINKER_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+      export OPENSSL_MODULES_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      # Note(Reza): The target must match the glibc version corresponding to the oldest supported host.
-      CXX="zig c++ -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" CC="zig cc -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" make build-container
+      make build-container SUBDIRS_CILIUM_CONTAINER='daemon cilium-health bugtool'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
+
+      # NOTE(reza): build a wrapper binary around cilium-sysctlfix and cilium-cni to set the correct LD_LIBRARY_PATH at runtime
+      cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
+      mkdir -p $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg $CRAFT_PART_BUILD/wrapper/bin
+
+
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix -ldflags "-X main.binaryName=cilium-sysctlfix -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni -ldflags "-X main.binaryName=cilium-cni -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg -ldflags "-X main.binaryName=cilium-dbg -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+
 
       make install-container-binary
       make install-bash-completion
@@ -357,7 +369,23 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
-      
+
+  symlink-ld:
+    plugin: nil
+    override-build: |
+      LINKER=ld-linux-x86-64.so.2
+      LINKER_PATH=/lib64
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+        LINKER_PATH=/lib
+      fi
+
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      ln -sf /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3 \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+      ln -sf $LINKER_PATH/$LINKER \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+
   llvm:
     plugin: nil
     build-packages:

--- a/1.17.1/cilium/wrapper/README.md
+++ b/1.17.1/cilium/wrapper/README.md
@@ -1,0 +1,14 @@
+## Wrapper binary with LD_LIBRARY_PATH set
+
+This software provides a wrapper around an arbitrary binary, ensuring it always runs with a fixed
+LD_LIBRARY_PATH environment variable set at runtime. Both the target binary and the value of
+LD_LIBRARY_PATH must be provided at build time:
+
+```
+go build -o wrapper-bin -ldflags "-X main.binaryName=<BINARY_NAME> -X main.ldLibraryPath=<LD_LIBRARY_PATH>" main.go
+```
+
+This is needed for the Cilium rock image since the Cilium binaries are built with
+dynamic linking and may sometimes run outside the namespaces of their container.
+While setting RPATH works for direct dependencies, indirect dependencies are not resolved correctly.
+This wrapper ensures all dynamic links resolve to the correct libraries.

--- a/1.17.1/cilium/wrapper/go.mod
+++ b/1.17.1/cilium/wrapper/go.mod
@@ -1,0 +1,3 @@
+module github.com/canonical/cilium-rocks/wrapper
+
+go 1.24.6

--- a/1.17.1/cilium/wrapper/main.go
+++ b/1.17.1/cilium/wrapper/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"embed"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+//go:embed bin/*
+var embeddedFiles embed.FS
+
+var binaryName string
+var ldLibraryPath string
+var opensslmodulesPath string
+
+func run() (exitCode int) {
+
+	binaryData, err := embeddedFiles.ReadFile("bin/" + binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read embedded binary %q: %v\n", binaryName, err)
+		return 1
+	}
+
+	f, err := os.CreateTemp("", binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp file: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove the embedded binary: %v\n", err)
+		}
+	}()
+
+	if _, err := f.Write(binaryData); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write embedded binary: %v\n", err)
+		return 1
+	}
+
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close the temp file: %v\n", err)
+		return 1
+	}
+
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to make the embedded binary executable: %v\n", err)
+		return 1
+	}
+
+	// Prepare command with custom environment variables
+	cmd := exec.Command(f.Name(), os.Args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
+		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
+	)
+
+	// Connect stdin/stdout/stderr to this process
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the binary
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ProcessState.ExitCode()
+		} else {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/1.17.1/cilium/wrapper/main.go
+++ b/1.17.1/cilium/wrapper/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
+	"syscall"
 )
 
 //go:embed bin/*
@@ -49,28 +48,17 @@ func run() (exitCode int) {
 		return 1
 	}
 
-	// Prepare command with custom environment variables
-	cmd := exec.Command(f.Name(), os.Args[1:]...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
-		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
-	)
+	// Set environment variables for the target binary
+	os.Setenv("LD_LIBRARY_PATH", ldLibraryPath)
+	os.Setenv("OPENSSL_MODULES", opensslmodulesPath)
 
-	// Connect stdin/stdout/stderr to this process
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	// Run the binary
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return exitErr.ProcessState.ExitCode()
-		} else {
-			return 1
-		}
+	// Replace current process with the target binary (execve)
+	if err := syscall.Exec(f.Name(), append([]string{f.Name()}, os.Args[1:]...), os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to exec %s: %v\n", binaryName, err)
+		return 1
 	}
 
+	// unreachable if exec succeeds
 	return 0
 }
 

--- a/1.17.12/cilium/rockcraft.yaml
+++ b/1.17.12/cilium/rockcraft.yaml
@@ -4,6 +4,9 @@ description: This rock is a drop in replacement for the cilium/cilium image.
 version: "1.17.12"
 license: Apache-2.0
 
+# Note(Reza): We are hardcoding the dynamic libraries path inside the cilium
+# part binaries. Change them and also the LD_LIBRARY_PATH in the wrapper codebase
+# accodingly when you change the base snap.
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 platforms:
@@ -273,25 +276,15 @@ parts:
       - openssl-fips-module-3 # a Pro only FIPS package for openssl
       - openssl # now automatically selected from fips-preview
 
-  zig:
-    plugin: nil
-    build-packages:
-      - tar
-      - curl
-    override-build: |
-      ARCH=x86_64
-      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        ARCH=aarch64
-      fi
-
-      curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
-      mkdir -p /zig
-      tar --strip-components 1 -xf zig.tar.xz -C /zig
-
-      ln -sf /zig/zig /usr/bin/zig
+  wrapper:
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+    - wrapper
 
   cilium:
-    after: [build-deps, builder-img-deps, zig]
+    after: [build-deps, builder-img-deps, wrapper]
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
@@ -305,22 +298,41 @@ parts:
      - GOTOOLCHAIN: local
      - GOEXPERIMENT: opensslcrypto
      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
-     - GO_BUILD_LDFLAGS: "-linkmode external"
      - PKG_BUILD: "1"
      - NOSTRIP: "0"
      - NOOPT: "0"
     override-build: |
-      export DESTDIR=$CRAFT_PART_INSTALL
-
       # NOTE: (mateoflorido) Something is changing the requested version
       # in the build-snaps section.
       snap refresh go --channel 1.24-fips/stable
 
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      LINKER=ld-linux-x86-64.so.2
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+      fi
+
+      export LIBRARY_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      export DYNAMIC_LINKER_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+      export OPENSSL_MODULES_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      # Note(Reza): The target must match the glibc version corresponding to the oldest supported host.
-      CXX="zig c++ -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" CC="zig cc -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" make build-container
+      make build-container SUBDIRS_CILIUM_CONTAINER='daemon cilium-health bugtool'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
+
+      # NOTE(reza): build a wrapper binary around cilium-sysctlfix and cilium-cni to set the correct LD_LIBRARY_PATH at runtime
+      cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
+      mkdir -p $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg $CRAFT_PART_BUILD/wrapper/bin
+
+
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix -ldflags "-X main.binaryName=cilium-sysctlfix -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni -ldflags "-X main.binaryName=cilium-cni -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg -ldflags "-X main.binaryName=cilium-dbg -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+
 
       make install-container-binary
       make install-bash-completion
@@ -337,7 +349,6 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/etc/bash_completion.d
       $CRAFT_PART_INSTALL/usr/bin/hubble completion bash > $CRAFT_PART_INSTALL/etc/bash_completion.d/hubble
 
-
       echo 'install_cni "/usr/bin/cilium-dbg"' >> $CRAFT_PART_BUILD/plugins/cilium-cni/install-plugin.sh
 
       cp $CRAFT_PART_BUILD/LICENSE.all  $CRAFT_PART_INSTALL/
@@ -349,6 +360,22 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
+
+  symlink-ld:
+    plugin: nil
+    override-build: |
+      LINKER=ld-linux-x86-64.so.2
+      LINKER_PATH=/lib64
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+        LINKER_PATH=/lib
+      fi
+
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      ln -sf /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3 \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+      ln -sf $LINKER_PATH/$LINKER \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
 
   llvm:
     plugin: nil

--- a/1.17.12/cilium/wrapper/README.md
+++ b/1.17.12/cilium/wrapper/README.md
@@ -1,0 +1,14 @@
+## Wrapper binary with LD_LIBRARY_PATH set
+
+This software provides a wrapper around an arbitrary binary, ensuring it always runs with a fixed
+LD_LIBRARY_PATH environment variable set at runtime. Both the target binary and the value of
+LD_LIBRARY_PATH must be provided at build time:
+
+```
+go build -o wrapper-bin -ldflags "-X main.binaryName=<BINARY_NAME> -X main.ldLibraryPath=<LD_LIBRARY_PATH>" main.go
+```
+
+This is needed for the Cilium rock image since the Cilium binaries are built with
+dynamic linking and may sometimes run outside the namespaces of their container.
+While setting RPATH works for direct dependencies, indirect dependencies are not resolved correctly.
+This wrapper ensures all dynamic links resolve to the correct libraries.

--- a/1.17.12/cilium/wrapper/go.mod
+++ b/1.17.12/cilium/wrapper/go.mod
@@ -1,0 +1,3 @@
+module github.com/canonical/cilium-rocks/wrapper
+
+go 1.24.6

--- a/1.17.12/cilium/wrapper/main.go
+++ b/1.17.12/cilium/wrapper/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"embed"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+//go:embed bin/*
+var embeddedFiles embed.FS
+
+var binaryName string
+var ldLibraryPath string
+var opensslmodulesPath string
+
+func run() (exitCode int) {
+
+	binaryData, err := embeddedFiles.ReadFile("bin/" + binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read embedded binary %q: %v\n", binaryName, err)
+		return 1
+	}
+
+	f, err := os.CreateTemp("", binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp file: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove the embedded binary: %v\n", err)
+		}
+	}()
+
+	if _, err := f.Write(binaryData); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write embedded binary: %v\n", err)
+		return 1
+	}
+
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close the temp file: %v\n", err)
+		return 1
+	}
+
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to make the embedded binary executable: %v\n", err)
+		return 1
+	}
+
+	// Prepare command with custom environment variables
+	cmd := exec.Command(f.Name(), os.Args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
+		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
+	)
+
+	// Connect stdin/stdout/stderr to this process
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the binary
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ProcessState.ExitCode()
+		} else {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/1.17.12/cilium/wrapper/main.go
+++ b/1.17.12/cilium/wrapper/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
+	"syscall"
 )
 
 //go:embed bin/*
@@ -49,28 +48,17 @@ func run() (exitCode int) {
 		return 1
 	}
 
-	// Prepare command with custom environment variables
-	cmd := exec.Command(f.Name(), os.Args[1:]...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
-		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
-	)
+	// Set environment variables for the target binary
+	os.Setenv("LD_LIBRARY_PATH", ldLibraryPath)
+	os.Setenv("OPENSSL_MODULES", opensslmodulesPath)
 
-	// Connect stdin/stdout/stderr to this process
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	// Run the binary
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return exitErr.ProcessState.ExitCode()
-		} else {
-			return 1
-		}
+	// Replace current process with the target binary (execve)
+	if err := syscall.Exec(f.Name(), append([]string{f.Name()}, os.Args[1:]...), os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to exec %s: %v\n", binaryName, err)
+		return 1
 	}
 
+	// unreachable if exec succeeds
 	return 0
 }
 

--- a/1.17.9/cilium/rockcraft.yaml
+++ b/1.17.9/cilium/rockcraft.yaml
@@ -4,6 +4,9 @@ description: This rock is a drop in replacement for the cilium/cilium image.
 version: "1.17.9"
 license: Apache-2.0
 
+# Note(Reza): We are hardcoding the dynamic libraries path inside the cilium
+# part binaries. Change them and also the LD_LIBRARY_PATH in the wrapper codebase
+# accodingly when you change the base snap.
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 platforms:
@@ -293,25 +296,15 @@ parts:
       - openssl-fips-module-3 # a Pro only FIPS package for openssl
       - openssl # now automatically selected from fips-preview
 
-  zig:
-    plugin: nil
-    build-packages:
-      - tar
-      - curl
-    override-build: |
-      ARCH=x86_64
-      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        ARCH=aarch64
-      fi
+  wrapper:
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+    - wrapper
 
-      curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
-      mkdir -p /zig
-      tar --strip-components 1 -xf zig.tar.xz -C /zig
-
-      ln -sf /zig/zig /usr/bin/zig  
-  
   cilium:
-    after: [build-deps, builder-img-deps, zig]
+    after: [build-deps, builder-img-deps, wrapper]
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
@@ -325,22 +318,41 @@ parts:
      - GOTOOLCHAIN: local
      - GOEXPERIMENT: opensslcrypto
      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
-     - GO_BUILD_LDFLAGS: "-linkmode external"
      - PKG_BUILD: "1"
      - NOSTRIP: "0"
      - NOOPT: "0"
     override-build: |
-      export DESTDIR=$CRAFT_PART_INSTALL
-
       # NOTE: (mateoflorido) Something is changing the requested version
       # in the build-snaps section.
       snap refresh go --channel 1.24-fips/stable
-      
+
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      LINKER=ld-linux-x86-64.so.2
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+      fi
+
+      export LIBRARY_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      export DYNAMIC_LINKER_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+      export OPENSSL_MODULES_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      # Note(Reza): The target must match the glibc version corresponding to the oldest supported host.
-      CXX="zig c++ -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" CC="zig cc -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" make build-container
+      make build-container SUBDIRS_CILIUM_CONTAINER='daemon cilium-health bugtool'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
+
+      # NOTE(reza): build a wrapper binary around cilium-sysctlfix and cilium-cni to set the correct LD_LIBRARY_PATH at runtime
+      cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
+      mkdir -p $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg $CRAFT_PART_BUILD/wrapper/bin
+
+
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix -ldflags "-X main.binaryName=cilium-sysctlfix -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni -ldflags "-X main.binaryName=cilium-cni -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg -ldflags "-X main.binaryName=cilium-dbg -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+
 
       make install-container-binary
       make install-bash-completion
@@ -357,7 +369,23 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
-  
+
+  symlink-ld:
+    plugin: nil
+    override-build: |
+      LINKER=ld-linux-x86-64.so.2
+      LINKER_PATH=/lib64
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+        LINKER_PATH=/lib
+      fi
+
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      ln -sf /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3 \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+      ln -sf $LINKER_PATH/$LINKER \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+
   llvm:
     plugin: nil
     build-packages:

--- a/1.17.9/cilium/wrapper/README.md
+++ b/1.17.9/cilium/wrapper/README.md
@@ -1,0 +1,14 @@
+## Wrapper binary with LD_LIBRARY_PATH set
+
+This software provides a wrapper around an arbitrary binary, ensuring it always runs with a fixed
+LD_LIBRARY_PATH environment variable set at runtime. Both the target binary and the value of
+LD_LIBRARY_PATH must be provided at build time:
+
+```
+go build -o wrapper-bin -ldflags "-X main.binaryName=<BINARY_NAME> -X main.ldLibraryPath=<LD_LIBRARY_PATH>" main.go
+```
+
+This is needed for the Cilium rock image since the Cilium binaries are built with
+dynamic linking and may sometimes run outside the namespaces of their container.
+While setting RPATH works for direct dependencies, indirect dependencies are not resolved correctly.
+This wrapper ensures all dynamic links resolve to the correct libraries.

--- a/1.17.9/cilium/wrapper/go.mod
+++ b/1.17.9/cilium/wrapper/go.mod
@@ -1,0 +1,3 @@
+module github.com/canonical/cilium-rocks/wrapper
+
+go 1.24.6

--- a/1.17.9/cilium/wrapper/main.go
+++ b/1.17.9/cilium/wrapper/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"embed"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+//go:embed bin/*
+var embeddedFiles embed.FS
+
+var binaryName string
+var ldLibraryPath string
+var opensslmodulesPath string
+
+func run() (exitCode int) {
+
+	binaryData, err := embeddedFiles.ReadFile("bin/" + binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read embedded binary %q: %v\n", binaryName, err)
+		return 1
+	}
+
+	f, err := os.CreateTemp("", binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp file: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove the embedded binary: %v\n", err)
+		}
+	}()
+
+	if _, err := f.Write(binaryData); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write embedded binary: %v\n", err)
+		return 1
+	}
+
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close the temp file: %v\n", err)
+		return 1
+	}
+
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to make the embedded binary executable: %v\n", err)
+		return 1
+	}
+
+	// Prepare command with custom environment variables
+	cmd := exec.Command(f.Name(), os.Args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
+		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
+	)
+
+	// Connect stdin/stdout/stderr to this process
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the binary
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ProcessState.ExitCode()
+		} else {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/1.17.9/cilium/wrapper/main.go
+++ b/1.17.9/cilium/wrapper/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
+	"syscall"
 )
 
 //go:embed bin/*
@@ -49,28 +48,17 @@ func run() (exitCode int) {
 		return 1
 	}
 
-	// Prepare command with custom environment variables
-	cmd := exec.Command(f.Name(), os.Args[1:]...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
-		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
-	)
+	// Set environment variables for the target binary
+	os.Setenv("LD_LIBRARY_PATH", ldLibraryPath)
+	os.Setenv("OPENSSL_MODULES", opensslmodulesPath)
 
-	// Connect stdin/stdout/stderr to this process
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	// Run the binary
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return exitErr.ProcessState.ExitCode()
-		} else {
-			return 1
-		}
+	// Replace current process with the target binary (execve)
+	if err := syscall.Exec(f.Name(), append([]string{f.Name()}, os.Args[1:]...), os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to exec %s: %v\n", binaryName, err)
+		return 1
 	}
 
+	// unreachable if exec succeeds
 	return 0
 }
 

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -4,6 +4,9 @@ description: This rock is a drop in replacement for the cilium/cilium image.
 version: "1.18.4"
 license: Apache-2.0
 
+# Note(Reza): We are hardcoding the dynamic libraries path inside the cilium
+# part binaries. Change them and also the LD_LIBRARY_PATH in the wrapper codebase
+# accodingly when you change the base snap.
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 platforms:
@@ -292,25 +295,15 @@ parts:
       - openssl-fips-module-3 # a Pro only FIPS package for openssl
       - openssl # now automatically selected from fips-preview
 
-  zig:
-    plugin: nil
-    build-packages:
-      - tar
-      - curl
-    override-build: |
-      ARCH=x86_64
-      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        ARCH=aarch64
-      fi
+  wrapper:
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+    - wrapper
 
-      curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
-      mkdir -p /zig
-      tar --strip-components 1 -xf zig.tar.xz -C /zig
-
-      ln -sf /zig/zig /usr/bin/zig
-  
   cilium:
-    after: [build-deps, builder-img-deps, zig]
+    after: [build-deps, builder-img-deps, wrapper]
     plugin: make
     source-type: git
     source: https://github.com/cilium/cilium.git
@@ -324,22 +317,41 @@ parts:
      - GOTOOLCHAIN: local
      - GOEXPERIMENT: opensslcrypto
      - GO_TAGS_FLAGS: "linux,cgo,ms_tls13kdf"
-     - GO_BUILD_LDFLAGS: "-linkmode external"
      - PKG_BUILD: "1"
      - NOSTRIP: "0"
      - NOOPT: "0"
     override-build: |
-      export DESTDIR=$CRAFT_PART_INSTALL
-
       # NOTE: (mateoflorido) Something is changing the requested version
       # in the build-snaps section.
       snap refresh go --channel 1.24-fips/stable
-      
+
+      export DESTDIR=$CRAFT_PART_INSTALL
+
+      LINKER=ld-linux-x86-64.so.2
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+      fi
+
+      export LIBRARY_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      export DYNAMIC_LINKER_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+      export OPENSSL_MODULES_PATH=/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+
       # NOTE (mateoflorido): Patch Cilium Makefiles to use FIPS-compatible build flags
       find . -name "Makefile*" -exec sed -i 's/CGO_ENABLED=0/CGO_ENABLED=1/g' {} \;
 
-      # Note(Reza): The target must match the glibc version corresponding to the oldest supported host.
-      CXX="zig c++ -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" CC="zig cc -target ${CRAFT_ARCH_TRIPLET_BUILD_FOR}.2.31" make build-container
+      make build-container SUBDIRS_CILIUM_CONTAINER='daemon cilium-health bugtool'
+      make build-container SUBDIRS_CILIUM_CONTAINER='cilium-dbg tools/mount tools/sysctlfix plugins/cilium-cni' GO_BUILD_LDFLAGS='-linkmode external -extldflags "-Wl,-dynamic-linker,${DYNAMIC_LINKER_PATH} -Wl,-rpath,${LIBRARY_PATH}"'
+
+      # NOTE(reza): build a wrapper binary around cilium-sysctlfix and cilium-cni to set the correct LD_LIBRARY_PATH at runtime
+      cp -r $CRAFT_STAGE/wrapper  $CRAFT_PART_BUILD/wrapper
+      mkdir -p $CRAFT_PART_BUILD/wrapper/bin
+      cp $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg $CRAFT_PART_BUILD/wrapper/bin
+
+
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/tools/sysctlfix/cilium-sysctlfix -ldflags "-X main.binaryName=cilium-sysctlfix -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/plugins/cilium-cni/cilium-cni -ldflags "-X main.binaryName=cilium-cni -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+      CGO_ENABLED=0 GOEXPERIMENT= GOTOOLCHAIN=auto go build -o $CRAFT_PART_BUILD/cilium-dbg/cilium-dbg -ldflags "-X main.binaryName=cilium-dbg -X main.ldLibraryPath=${LIBRARY_PATH} -X main.opensslmodulesPath=${OPENSSL_MODULES_PATH}" wrapper/main.go
+
 
       make install-container-binary
       make install-bash-completion
@@ -356,7 +368,23 @@ parts:
     override-prime: |
       craftctl default
       rm -rf /root/.cache/go-build
-  
+
+  symlink-ld:
+    plugin: nil
+    override-build: |
+      LINKER=ld-linux-x86-64.so.2
+      LINKER_PATH=/lib64
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
+        LINKER=ld-linux-aarch64.so.1
+        LINKER_PATH=/lib
+      fi
+
+      mkdir -p ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      ln -sf /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3 \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules-3
+      ln -sf $LINKER_PATH/$LINKER \
+          ${CRAFT_PART_INSTALL}/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/$LINKER
+
   llvm:
     plugin: nil
     build-packages:

--- a/1.18.4/cilium/wrapper/README.md
+++ b/1.18.4/cilium/wrapper/README.md
@@ -1,0 +1,14 @@
+## Wrapper binary with LD_LIBRARY_PATH set
+
+This software provides a wrapper around an arbitrary binary, ensuring it always runs with a fixed
+LD_LIBRARY_PATH environment variable set at runtime. Both the target binary and the value of
+LD_LIBRARY_PATH must be provided at build time:
+
+```
+go build -o wrapper-bin -ldflags "-X main.binaryName=<BINARY_NAME> -X main.ldLibraryPath=<LD_LIBRARY_PATH>" main.go
+```
+
+This is needed for the Cilium rock image since the Cilium binaries are built with
+dynamic linking and may sometimes run outside the namespaces of their container.
+While setting RPATH works for direct dependencies, indirect dependencies are not resolved correctly.
+This wrapper ensures all dynamic links resolve to the correct libraries.

--- a/1.18.4/cilium/wrapper/go.mod
+++ b/1.18.4/cilium/wrapper/go.mod
@@ -1,0 +1,3 @@
+module github.com/canonical/cilium-rocks/wrapper
+
+go 1.24.6

--- a/1.18.4/cilium/wrapper/main.go
+++ b/1.18.4/cilium/wrapper/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"embed"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+//go:embed bin/*
+var embeddedFiles embed.FS
+
+var binaryName string
+var ldLibraryPath string
+var opensslmodulesPath string
+
+func run() (exitCode int) {
+
+	binaryData, err := embeddedFiles.ReadFile("bin/" + binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read embedded binary %q: %v\n", binaryName, err)
+		return 1
+	}
+
+	f, err := os.CreateTemp("", binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp file: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove the embedded binary: %v\n", err)
+		}
+	}()
+
+	if _, err := f.Write(binaryData); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write embedded binary: %v\n", err)
+		return 1
+	}
+
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close the temp file: %v\n", err)
+		return 1
+	}
+
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to make the embedded binary executable: %v\n", err)
+		return 1
+	}
+
+	// Prepare command with custom environment variables
+	cmd := exec.Command(f.Name(), os.Args[1:]...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
+		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
+	)
+
+	// Connect stdin/stdout/stderr to this process
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the binary
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ProcessState.ExitCode()
+		} else {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(run())
+}

--- a/1.18.4/cilium/wrapper/main.go
+++ b/1.18.4/cilium/wrapper/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
+	"syscall"
 )
 
 //go:embed bin/*
@@ -49,28 +48,17 @@ func run() (exitCode int) {
 		return 1
 	}
 
-	// Prepare command with custom environment variables
-	cmd := exec.Command(f.Name(), os.Args[1:]...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("LD_LIBRARY_PATH=%s", ldLibraryPath),
-		fmt.Sprintf("OPENSSL_MODULES=%s", opensslmodulesPath),
-	)
+	// Set environment variables for the target binary
+	os.Setenv("LD_LIBRARY_PATH", ldLibraryPath)
+	os.Setenv("OPENSSL_MODULES", opensslmodulesPath)
 
-	// Connect stdin/stdout/stderr to this process
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	// Run the binary
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return exitErr.ProcessState.ExitCode()
-		} else {
-			return 1
-		}
+	// Replace current process with the target binary (execve)
+	if err := syscall.Exec(f.Name(), append([]string{f.Name()}, os.Args[1:]...), os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to exec %s: %v\n", binaryName, err)
+		return 1
 	}
 
+	// unreachable if exec succeeds
 	return 0
 }
 

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -44,17 +44,27 @@ setup of Cilium.
 For Canonical Kubernetes, there is no supported path to enable the WireGuard feature.
 Therefore, deployments using the default Cilium configurations are FIPS-compliant.
 
-## Using Zig to link against specific glibc versions
+## Cilium Wrapper Binary
 
-The Cilium Helm chart is used to deploy Cilium on a Kubernetes cluster and utilizes this Rock.
-It has a few init containers that copy binaries from inside the image to the host and
-run them within the host namespace. Since we are dynamically building these binaries,
-to make sure they are working on the oldest supported host we are linking against
-glibc shipped with the oldest supported host for each image.
-The [Zig compiler] allows us to achieve that without changing the image base.
+The Cilium Helm chart, which is used to deploy Cilium on a Kubernetes cluster
+and utilizes this Rock, has a few init containers that copy binaries from
+inside the image to the host and run them within the host namespace. Since we
+are building these binaries with dynamic linking, to make sure the dependencies
+are always present on the machines, we have linked the binaries against
+libraries from the `core22` snap package using `RPATH` at build time and
+`LD_LIBRARY_PATH` at runtime. We also have modified the binaries to use
+the dynamic linker from `core22` for compatibility.
+
+However, since the OpenSSL shipped with the `core22` snap package is using the
+modules like the FIPS module from the host, this modification doesn't work out
+of the box. To make sure we are using the right FIPS module when calling the
+OpenSSL library, we also provide the FIPS module path shipped with `core22`
+using the `OPENSSL_MODULES` environment variable at runtime.
+
+To provide the runtime environment variables, binaries are embedded inside a
+wrapper binary that provides these values when the binary is executed.
 
 <!-- LINKS -->
 
-[Zig compiler]: https://snapcraft.io/zig
 [IPsec]: https://docs.cilium.io/en/latest/security/network/encryption-ipsec/
 [TLS inspection]: https://docs.cilium.io/en/latest/security/tls-visibility/


### PR DESCRIPTION
This PR reverts b318121 and zig related changes. We will go back to using the wrapper to link against core22 libraries to ensure the image can run on any host.