### PR TITLE
fix: build cilium-envoy proxylib with go 1.25-fips for proxy v1.34

### DIFF
--- a/1.17.12/cilium/rockcraft.yaml
+++ b/1.17.12/cilium/rockcraft.yaml
@@ -94,6 +94,12 @@ parts:
       export EMAIL=root@localhost
       git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
 
+      # cilium/proxy v1.34's go.mod requires Go >= 1.25.0. FIPS Go pins
+      # GOTOOLCHAIN=local, so it won't auto-fetch a newer toolchain like the
+      # non-FIPS snap does. Refresh the global go snap to 1.25-fips just for
+      # the proxylib build; later go parts re-refresh to 1.24-fips themselves.
+      snap refresh go --channel 1.25-fips/stable
+
       make -C proxylib all
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/
       cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/

--- a/1.17.9/cilium/rockcraft.yaml
+++ b/1.17.9/cilium/rockcraft.yaml
@@ -94,6 +94,12 @@ parts:
       export EMAIL=root@localhost
       git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
 
+      # cilium/proxy v1.34's go.mod requires Go >= 1.25.0. FIPS Go pins
+      # GOTOOLCHAIN=local, so it won't auto-fetch a newer toolchain like the
+      # non-FIPS snap does. Refresh the global go snap to 1.25-fips just for
+      # the proxylib build; later go parts re-refresh to 1.24-fips themselves.
+      snap refresh go --channel 1.25-fips/stable
+
       make -C proxylib all
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/
       cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/

--- a/1.18.4/cilium/rockcraft.yaml
+++ b/1.18.4/cilium/rockcraft.yaml
@@ -94,6 +94,12 @@ parts:
       export EMAIL=root@localhost
       git am --ignore-whitespace $CRAFT_PROJECT_DIR/envoy-fixes.patch
 
+      # cilium/proxy v1.34's go.mod requires Go >= 1.25.0. FIPS Go pins
+      # GOTOOLCHAIN=local, so it won't auto-fetch a newer toolchain like the
+      # non-FIPS snap does. Refresh the global go snap to 1.25-fips just for
+      # the proxylib build; later go parts re-refresh to 1.24-fips themselves.
+      snap refresh go --channel 1.25-fips/stable
+
       make -C proxylib all
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/
       cp proxylib/libcilium.so $CRAFT_PART_INSTALL/usr/lib/


### PR DESCRIPTION
## Summary
- Fixes the `cilium-envoy` proxylib build failure for the `1.17.9`, `1.17.12`, and `1.18.4` cilium rocks, which broke the post-merge **Push Multiarch Images** run for #57 and prevented the `1.19.4-ck0` manifest from publishing.
- These three rocks pin `cilium/proxy` `source-tag: v1.34`, whose `go.mod` requires Go `>= 1.25.0`, but they install `go/1.24-fips/stable` to match the upstream Cilium builder.
- FIPS Go pins `GOTOOLCHAIN=local`, so unlike the non-FIPS snap it will **not** auto-fetch a newer toolchain, producing:
  ```
  go: ../go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
  make: *** [Makefile:29: libcilium.so] Error 1
  'override-build' in part 'cilium-envoy' failed with code 2
  ```

## Fix
- Add `snap refresh go --channel 1.25-fips/stable` to the **`cilium-envoy` part only**, immediately before `make -C proxylib all`.
- Each later go-using part already runs its own `snap refresh go --channel 1.24-fips/stable`, so the agent and all other components remain on Go 1.24-fips (matching the upstream builder). The change is self-contained to the envoy proxylib build.

## Scope / intentionally untouched
- `1.17.1` uses proxy `v1.31` (go.mod ≤ 1.24) — unaffected.
- The non-FIPS `static` variants use `go/1.24/stable`, which auto-downloads 1.25 — unaffected.
- `1.19.4` already installs `go/1.25-fips/stable` globally — used as the reference for this fix.

## Validation
- Diff is exactly three identical hunks, all inside the `cilium-envoy` `override-build`.
- Matches the existing per-part `snap refresh go` pattern already used throughout these files.