### PR TITLE
feat(1.19.4): add s390x and ppc64el

### DIFF
--- a/1.19.4/cilium-operator-generic/rockcraft.yaml
+++ b/1.19.4/cilium-operator-generic/rockcraft.yaml
@@ -9,6 +9,8 @@ build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:
+  ppc64el:
+  s390x:
 
 environment:
   GOPS_CONFIG_DIR: "/"

--- a/1.19.4/cilium/rockcraft.yaml
+++ b/1.19.4/cilium/rockcraft.yaml
@@ -9,6 +9,8 @@ build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:
+  ppc64el:
+  s390x:
 
 package-repositories:
   - type: apt

--- a/1.19.4/cilium/rockcraft.yaml
+++ b/1.19.4/cilium/rockcraft.yaml
@@ -347,10 +347,15 @@ parts:
       - tar
       - curl
     override-build: |
-      ARCH=x86_64
-      if [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        ARCH=aarch64
-      fi
+      # zig's arch token differs from the rockcraft/debian arch name:
+      # ppc64el -> powerpc64le (not ppc64le), everything else maps 1:1.
+      case "$CRAFT_ARCH_BUILD_FOR" in
+        amd64)   ARCH=x86_64 ;;
+        arm64)   ARCH=aarch64 ;;
+        ppc64el) ARCH=powerpc64le ;;
+        s390x)   ARCH=s390x ;;
+        *) echo "unsupported arch for zig: $CRAFT_ARCH_BUILD_FOR" >&2; exit 1 ;;
+      esac
 
       curl -L https://ziglang.org/download/0.15.2/zig-$ARCH-linux-0.15.2.tar.xz -o zig.tar.xz
       mkdir -p /zig


### PR DESCRIPTION
add `s390x` and `ppc64el` arches to latest cilium.

related to:

- https://github.com/canonical/apache2-rock/pull/5